### PR TITLE
attribute error fix, calling str method on non str dtype

### DIFF
--- a/presidio_evaluator/data_generator/generator.py
+++ b/presidio_evaluator/data_generator/generator.py
@@ -92,7 +92,7 @@ class FakeDataGenerator:
         # Remove brackets as they interfere with the process
 
         def remove_brackets(series):
-            if series.dtype == object or series.dtype == str:
+            if series.dtype == str:
                 series = series.str.replace("[", "(")
                 series = series.str.replace("]", ")")
             return series


### PR DESCRIPTION
To recreate AttributeError run `pytest`

<img width="922" alt="image" src="https://user-images.githubusercontent.com/2048170/75581832-28031c80-5a1f-11ea-974b-de513e7593bf.png">

