### PR TITLE
modified file paths and variable declarations

### DIFF
--- a/notebooks/Generate data.ipynb
+++ b/notebooks/Generate data.ipynb
@@ -72,19 +72,19 @@
     "EXAMPLES = 100\n",
     "SPAN_TO_TAG = True #Whether to create tokens + token labels (tags)\n",
     "TEMPLATES_FILE = '../presidio_evaluator/data_generator/' \\\n",
-    "                 'raw_data/ontonotes_based_templates.txt'\n",
+    "                 'raw_data/templates.txt'\n",
     "KEEP_ONLY_TAGGED = False\n",
     "LOWER_CASE_RATIO = 0.1\n",
     "IGNORE_TYPES = {\"IP_ADDRESS\", 'US_SSN', 'URL'}\n",
     "\n",
-    "OUTPUT = \"generated_size_{}_date_{}.txt\".format(EXAMPLES, cur_time)\n",
+    "cur_time = datetime.date.today().strftime(\"%B_%d_%Y\")\n",
     "\n",
-    "cur_time = datetime.date.today().strftime(\"%B %d %Y\")\n",
+    "OUTPUT = \"../data/generated_size_{}_date_{}.json\".format(EXAMPLES, cur_time)\n",
+    "\n",
     "fake_pii_csv = '../presidio_evaluator/data_generator/' \\\n",
-    "               'raw_data/FakeNameGenerator.com_100.csv'\n",
+    "               'raw_data/FakeNameGenerator.com_3000.csv'\n",
     "utterances_file = TEMPLATES_FILE\n",
-    "dictionary_path = '../presidio_evaluator/data_generator/' \\\n",
-    "                  'raw_data/Dictionary.csv'\n",
+    "dictionary_path = None\n",
     "\n",
     "examples = generate(fake_pii_csv=fake_pii_csv,\n",
     "                        utterances_file=utterances_file,\n",
@@ -219,6 +219,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.4"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- `TEMPLATES_FILE` was pointing to a non-existent file.
- `cur_time` was being referenced before it was declared. Underscores added for better file naming. 
- `OUTPUT` was being saved as `.txt` when output is `.json`. Location of saved data file moved to `/data` directory.
- `fake_pii_csv` was pointing to a non-existent file.
