### PR TITLE
Explicitly include data files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-from glob import glob
 import os.path
 # read the contents of the README file
 from os import path
@@ -13,11 +12,6 @@ __version__ = ""
 with open(os.path.join(this_directory, 'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-data_files = []
-directory = 'presidio_evaluator/data_generator/raw_data/'
-files = glob(directory+'*')
-data_files.append((directory, files))
-
 setup(
     name='presidio-evaluator',
     long_description=long_description,
@@ -28,7 +22,7 @@ setup(
     url='https://www.github.com/microsoft/presidio',
     license='MIT',
     description='PII dataset generator, model evaluator for Presidio and PII data in general',
-    data_files=data_files,
+    data_files=[('presidio_evaluator/data_generator/raw_data', ['presidio_evaluator/data_generator/raw_data/FakeNameGenerator.com_3000.csv', 'presidio_evaluator/data_generator/raw_data/templates.txt', 'presidio_evaluator/data_generator/raw_data/organizations.csv', 'presidio_evaluator/data_generator/raw_data/nationalities.csv'])],
     include_package_data=True,
     install_requires=[
         'spacy>=2.2.0',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         'spacy>=2.2.0',
         'requests==2.22.0',
-        'numpy=',
+        'numpy',
         'pandas',
         'tqdm>=4.32.1',
         'jupyter>=1.0.0',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+from glob import glob
 import os.path
 # read the contents of the README file
 from os import path
@@ -12,6 +13,11 @@ __version__ = ""
 with open(os.path.join(this_directory, 'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
+data_files = []
+directory = 'presidio_evaluator/data_generator/raw_data/'
+files = glob(directory+'*')
+data_files.append((directory, files))
+
 setup(
     name='presidio-evaluator',
     long_description=long_description,
@@ -22,6 +28,8 @@ setup(
     url='https://www.github.com/microsoft/presidio',
     license='MIT',
     description='PII dataset generator, model evaluator for Presidio and PII data in general',
+    data_files=data_files,
+    include_package_data=True,
     install_requires=[
         'spacy>=2.2.0',
         'requests==2.22.0',


### PR DESCRIPTION
Hello, I found depending on the environment `setup.py` doesn't always include the data sub-folder. In my case this was when running the project inside a Docker container. For example:

```
FROM jupyter/datascience-notebook:python-3.7.6
WORKDIR work
COPY requirements.txt .
RUN pip install -r requirements.txt
COPY . .
RUN python ./setup.py install
```

The project would build but when trying to use the notebooks I found the `raw_data` folder was missing.

To fix the issue I tell `setup.py` to include the `raw_data` folder.