### PR TITLE
Remove param "self" in `to_flair_row` conflicts with line 28

### DIFF
--- a/models/flair_train.py
+++ b/models/flair_train.py
@@ -14,7 +14,7 @@ from os import path
 class FlairTrainer:
 
     @staticmethod
-    def to_flair_row(self, text, pos, label):
+    def to_flair_row(text, pos, label):
         return "{} {} {}".format(text, pos, label)
 
     def to_flair(self, df, outfile="flair_train.txt"):


### PR DESCRIPTION
Having progress with training the flair embeddings. Other than updating the generated datasets on lines 115-117 I found a small fix was needed on the `to_flair_row` function.

Either `self` could be removed as a parameter or the line calling the function (line 28) could add `self` as a parameter _(without one of these there is an error due to parameter mismatch)_. As `self` wasn't used removing it seemed the better option.