### PR TITLE
Update replacement for Flair evaluation

### DIFF
--- a/presidio_evaluator/flair_evaluator.py
+++ b/presidio_evaluator/flair_evaluator.py
@@ -1,4 +1,5 @@
 from typing import List
+import regex
 
 try:
     from flair.data import Sentence, build_spacy_tokenizer
@@ -69,6 +70,13 @@ class FlairEvaluator(ModelEvaluator):
 
         new_tags = []
         for tag in tags:
-            new_tags.append("PERSON" if tag == "PER" else tag)
+            #new_tags.append("PERSON" if tag == "PER" else tag)
+            is_person = regex.compile('[A-Z]-PER\\b')
+            if is_person.match(tag):
+                tag = tag.replace("PER", "PERSON")
+            is_gpe = regex.compile('[A-Z]-LOC\\b')
+            if is_gpe.match(tag):
+                tag = tag.replace("LOC", "GPE")
+            new_tags.append(tag)
 
         return new_tags

--- a/presidio_evaluator/flair_evaluator.py
+++ b/presidio_evaluator/flair_evaluator.py
@@ -70,7 +70,6 @@ class FlairEvaluator(ModelEvaluator):
 
         new_tags = []
         for tag in tags:
-            #new_tags.append("PERSON" if tag == "PER" else tag)
             is_person = regex.compile('[A-Z]-PER\\b')
             if is_person.match(tag):
                 tag = tag.replace("PER", "PERSON")


### PR DESCRIPTION
I noticed during the notebook `Evaluate flair models` the first 2 models `ner` and `fast-ner` don't produce results for `PERSON` or `GPE`.

When looking at the evaluation code I noticed the line:

    new_tags.append("PERSON" if tag == "PER" else tag)

This made me realize the problem was due to the model using different labels. I believe the intention of the line above was to replace the `PER` style tags with `PERSON`. However it never matches any tags because they are always start with a letter and dash for example `E-PERSON` or `S-PERSON`.

To fix this I replaced the `==` comparison with a regex based comparison and did the same thing with `LOC` which is expected to be `GPE` by the evaluator. Tested with both the 4 class NER and 18 class NER to make sure the regex only matches `PER` and not `PERSON`.