### PR TITLE
Add Presidio packages required dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
+        "presidio_analyzer",
+        "presidio_anonymizer",
         "spacy>=3.0.0",
         "requests",
         "numpy",


### PR DESCRIPTION
- The `presidio_anonymizer` package is used by `presidio_pseudonymize`
- The `presidio_analyzer` package is used by `presidio_pseudonymize`, `scorers` and `models`