### PR TITLE
Tokenize with any model

### DIFF
--- a/presidio_evaluator/data_generator/presidio_pseudonymize.py
+++ b/presidio_evaluator/data_generator/presidio_pseudonymize.py
@@ -31,10 +31,10 @@ class PresidioPseudonymization(PresidioDataGenerator):
             self.add_provider_alias("date_time", "DATE_TIME")
 
     def pseudonymize(
-            self,
-            original_text: str,
-            presidio_response: List[RecognizerResult],
-            count: int,
+        self,
+        original_text: str,
+        presidio_response: List[RecognizerResult],
+        count: int,
     ):
         """
 

--- a/presidio_evaluator/data_generator/presidio_pseudonymize.py
+++ b/presidio_evaluator/data_generator/presidio_pseudonymize.py
@@ -1,11 +1,9 @@
-from typing import List, Set, Dict
+from typing import List
 
 from presidio_analyzer import RecognizerResult
 from presidio_anonymizer import AnonymizerEngine
 
 from presidio_evaluator.data_generator import PresidioDataGenerator
-
-import pandas as pd
 
 
 class PresidioPseudonymization(PresidioDataGenerator):
@@ -33,10 +31,10 @@ class PresidioPseudonymization(PresidioDataGenerator):
             self.add_provider_alias("date_time", "DATE_TIME")
 
     def pseudonymize(
-        self,
-        original_text: str,
-        presidio_response: List[RecognizerResult],
-        count: int,
+            self,
+            original_text: str,
+            presidio_response: List[RecognizerResult],
+            count: int,
     ):
         """
 

--- a/presidio_evaluator/experiment_tracking/experiment_tracker.py
+++ b/presidio_evaluator/experiment_tracking/experiment_tracker.py
@@ -5,8 +5,8 @@ from typing import Dict, List
 
 class ExperimentTracker:
     def __init__(self):
-        self.parameters = None
-        self.metrics = None
+        self.parameters = dict()
+        self.metrics = dict()
         self.dataset_info = None
         self.confusion_matrix = None
         self.labels = None
@@ -15,14 +15,14 @@ class ExperimentTracker:
         self.parameters[key] = value
 
     def log_parameters(self, parameters: Dict):
-        for k, v in parameters.values():
+        for k, v in parameters.items():
             self.log_parameter(k, v)
 
     def log_metric(self, key: str, value: object):
         self.metrics[key] = value
 
     def log_metrics(self, metrics: Dict):
-        for k, v in metrics.values():
+        for k, v in metrics.items():
             self.log_metric(k, v)
 
     def log_dataset_hash(self, data: str):
@@ -49,5 +49,5 @@ class ExperimentTracker:
         datetime_val = time.strftime("%Y%m%d-%H%M%S")
         filename = f"experiment_{datetime_val}.json"
         print(f"saving experiment data to {filename}")
-        with open(filename) as json_file:
+        with open(filename, 'w') as json_file:
             json.dump(self.__dict__, json_file)

--- a/presidio_evaluator/span_to_tag.py
+++ b/presidio_evaluator/span_to_tag.py
@@ -107,6 +107,7 @@ def span_to_tag(
     tags: List[str],
     scores: Optional[List[float]] = None,
     tokens: Optional[Doc] = None,
+    token_model_version: str = "en_core_web_sm"
 ) -> List[str]:
     """
     Turns a list of start and end values with corresponding labels, into a NER
@@ -118,6 +119,7 @@ def span_to_tag(
     :param ends: list of indices where entities in the text end
     :param tags: list of entity names
     :param scores: score of tag (confidence)
+    :param token_model_version: version of the model used for tokenization if no tokens provided
     :return: list of strings, representing either BILUO or BIO for the input
     """
 
@@ -128,7 +130,7 @@ def span_to_tag(
     starts, ends, tags, scores = _handle_overlaps(starts, ends, tags, scores)
 
     if not tokens:
-        tokens = tokenize(text)
+        tokens = tokenize(text, token_model_version)
 
     io_tags = []
     for token in tokens:


### PR DESCRIPTION
- Enable user to specify spacy model to use for tokenisation. Currently the default `en_core_web_sm` is always used e.g.
    - `InputSample.from_faker_spans_result(spans_result, token_model_version='en_core_web_lg')`
    - `InputSample.read_dataset_json(dataset_path, token_model_version='en_core_web_lg')`
- Fix bugs in `experiment_tracker.py` where tries to iterate over key value pairs from `parameters.values()` instead of `parameters.items()` and file writing that errored if file didn't exist