### PR TITLE
Add FakerSpansResult and InputSample Utility Functions

### DIFF
--- a/presidio_evaluator/data_generator/faker_extensions/data_objects.py
+++ b/presidio_evaluator/data_generator/faker_extensions/data_objects.py
@@ -56,6 +56,7 @@ class FakerSpansResult:
 
     @classmethod
     def count_entities(cls, fake_records: List["FakerSpansResult"]) -> Counter:
+        """Count frequency of entity types in a list of FakerSpansResult."""
         count_per_entity_new = Counter()
         for record in fake_records:
             for span in record.spans:

--- a/presidio_evaluator/data_generator/faker_extensions/data_objects.py
+++ b/presidio_evaluator/data_generator/faker_extensions/data_objects.py
@@ -61,3 +61,21 @@ class FakerSpansResult:
             for span in record.spans:
                 count_per_entity_new[span.type] += 1
         return count_per_entity_new.most_common()
+
+    @classmethod
+    def load_dataset_from_file(cls, filename: str) -> List["FakerSpansResult"]:
+        """Load a dataset of FakerSpansResult from a JSON file."""
+        with open(filename, "r", encoding="utf-8") as f:
+            return [cls.fromJSON(line) for line in f.readlines()]
+
+    @classmethod
+    def update_entity_types(cls, dataset: List["FakerSpansResult"], entity_mapping: Dict[str, str]):
+        """Replace entity types using a translator dictionary."""
+        for sample in dataset:
+            # update entity types on spans
+            for span in sample.spans:
+                span.type = entity_mapping[span.type]
+            # update entity types on the template string
+            for key, value in entity_mapping.items():
+                sample.template = sample.template.replace(
+                    "{{" + key + "}}", "{{" + value + "}}")

--- a/presidio_evaluator/data_generator/faker_extensions/data_objects.py
+++ b/presidio_evaluator/data_generator/faker_extensions/data_objects.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 import dataclasses
 import json
 from typing import Optional, List
+from collections import Counter
+from typing import Dict
 
 
 @dataclass(eq=True)

--- a/presidio_evaluator/data_generator/faker_extensions/data_objects.py
+++ b/presidio_evaluator/data_generator/faker_extensions/data_objects.py
@@ -43,3 +43,21 @@ class FakerSpansResult:
                 "template_id": self.template_id,
             }
         )
+
+    @classmethod
+    def fromJSON(cls, json_string):
+        """Load a single FakerSpansResult from a JSON string."""
+        json_dict = json.loads(json_string)
+        converted_spans = []
+        for span_dict in json.loads(json_dict['spans']):
+            converted_spans.append(FakerSpan(**span_dict))
+        json_dict['spans'] = converted_spans
+        return cls(**json_dict)
+
+    @classmethod
+    def count_entities(cls, fake_records: List["FakerSpansResult"]) -> Counter:
+        count_per_entity_new = Counter()
+        for record in fake_records:
+            for span in record.spans:
+                count_per_entity_new[span.type] += 1
+        return count_per_entity_new.most_common()

--- a/presidio_evaluator/data_objects.py
+++ b/presidio_evaluator/data_objects.py
@@ -585,7 +585,6 @@ class InputSample(object):
         """Remove records with unsupported entities using passed in entity mapping translator."""
         filtered_records = []
         excluded_entities = set()
-
         for sample in dataset:
             supported = True
             for span in sample.spans:
@@ -597,3 +596,13 @@ class InputSample(object):
             if supported:
                 filtered_records.append(sample)
         return filtered_records
+
+    @classmethod
+    def convert_faker_spans(cls, fake_records: List[FakerSpansResult], create_tags_from_span=True, scheme="BILUO", token_model_version="en_core_web_sm") -> List["InputSample"]:
+        """tokenize and transform fake samples to list of InputSample objects"""
+        input_samples = [
+            InputSample.from_faker_spans_result(
+                faker_spans_result=fake_record, create_tags_from_span=create_tags_from_span, scheme=scheme, token_model_version=token_model_version)
+            for fake_record in tqdm(fake_records)
+        ]
+        return input_samples

--- a/presidio_evaluator/data_objects.py
+++ b/presidio_evaluator/data_objects.py
@@ -588,7 +588,7 @@ class InputSample(object):
         for sample in dataset:
             supported = True
             for span in sample.spans:
-                if not span.entity_type in entity_mapping.keys():
+                if span.entity_type not in entity_mapping.keys():
                     supported = False
                     if span.entity_type not in excluded_entities:
                         print(f"Filtering out unsupported entity {span.entity_type}")

--- a/presidio_evaluator/data_objects.py
+++ b/presidio_evaluator/data_objects.py
@@ -574,6 +574,7 @@ class InputSample(object):
 
     @classmethod
     def count_entities(cls, input_samples: List["InputSample"]) -> Counter:
+        """Count frequency of entities in a list of InputSample objects"""
         count_per_entity_new = Counter()
         for record in input_samples:
             for span in record.spans:
@@ -599,7 +600,7 @@ class InputSample(object):
 
     @classmethod
     def convert_faker_spans(cls, fake_records: List[FakerSpansResult], create_tags_from_span=True, scheme="BILUO", token_model_version="en_core_web_sm") -> List["InputSample"]:
-        """tokenize and transform fake samples to list of InputSample objects"""
+        """Tokenize and transform FakerSpansResult records to list of InputSample objects"""
         input_samples = [
             InputSample.from_faker_spans_result(
                 faker_spans_result=fake_record, create_tags_from_span=create_tags_from_span, scheme=scheme, token_model_version=token_model_version)

--- a/tests/data/faker_spans.json
+++ b/tests/data/faker_spans.json
@@ -1,0 +1,2 @@
+{"fake": "Dan is my name. Tel Aviv is my home.", "spans": "[{\"value\": \"Dan\", \"start\": 0, \"end\": 3, \"type\": \"name\"}, {\"value\": \"Tel Aviv\", \"start\": 16, \"end\": 24, \"type\": \"city\"}]", "template": "{{name}} is my name. {{city}} is my home", "template_id": 4}
+{"fake": "Dan is my name. Tel Aviv is my home.", "spans": "[{\"value\": \"Dan\", \"start\": 0, \"end\": 3, \"type\": \"name\"}, {\"value\": \"Tel Aviv\", \"start\": 16, \"end\": 24, \"type\": \"city\"}]", "template": "{{name}} is my name. {{city}} is my home", "template_id": 4}


### PR DESCRIPTION
Add class methods for loading and processing FakerSpansResult and InputSample.

A few of these are new:
`FakerSpansResult.fromJSON`
`FakerSpansResult.load_dataset_from_file`
`InputSample.remove_unsupported_entities`

Others are adapted from `notebooks/1_Generate_data.ipynb`. 
`FakerSpansResult.update_entity_types`
`FakerSpansResult.count_entities`
`InputSample.convert_faker_spans`
`InputSample.count_entities`

IMO having them as class methods improves usability. 