### PR TITLE
Add HospitalProvider capability

### DIFF
--- a/presidio_evaluator/data_generator/faker_extensions/__init__.py
+++ b/presidio_evaluator/data_generator/faker_extensions/__init__.py
@@ -10,6 +10,7 @@ from .providers import (
     AddressProviderNew,
     PhoneNumberProviderNew,
     AgeProvider,
+    HospitalProvider
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "PhoneNumberProviderNew",
     "AgeProvider",
     "RecordsFaker",
+    "HospitalProvider"
 ]

--- a/presidio_evaluator/data_generator/faker_extensions/providers.py
+++ b/presidio_evaluator/data_generator/faker_extensions/providers.py
@@ -306,8 +306,11 @@ class HospitalProvider(BaseProvider):
 
         '''
         r = requests.get(url, params={'format': 'json', 'query': query})
+        if r.status_code != 200:
+            print("Unable to read hospitals from WikiData, returning an empty list")
+            return list()
         data = r.json()
-        bindings = data['results']['bindings']
+        bindings = data['results'].get('bindings', [])
         hospitals = [self.deep_get(x, ['label_en', 'value']) for x in bindings]
         hospitals = [x for x in hospitals if 'no key' not in x]
         return hospitals

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3,6 +3,7 @@ from faker import Faker
 from presidio_evaluator.data_generator.faker_extensions import (
     NationalityProvider,
     OrganizationProvider,
+    HospitalProvider
 )
 
 
@@ -17,4 +18,11 @@ def test_organization_provider():
     faker = Faker()
     faker.add_provider(OrganizationProvider)
     element = faker.organization()
+    assert element
+
+
+def test_hospital_provider():
+    faker = Faker()
+    faker.add_provider(HospitalProvider)
+    element = faker.hospital_name()
     assert element


### PR DESCRIPTION
The HospitalProvider generates a list of hospital names located in the US.
The data is extracted by querying WikiData and querying for entities "hospital" (Q16917)
Which are located in the US and are functioning.
Another option to initialize the provider, is to provide a static file of hospital names for cases where no internet connection is available.