### PR TITLE
added a new method for tag_to_span

### DIFF
--- a/presidio_evaluator/__init__.py
+++ b/presidio_evaluator/__init__.py
@@ -1,4 +1,5 @@
 from .span_to_tag import span_to_tag, tokenize, io_to_scheme
+
 from .data_objects import Span, InputSample
 from .validation import (
     split_dataset,
@@ -7,6 +8,7 @@ from .validation import (
     group_by_template,
     save_to_json,
 )
+from .tag_to_span import tag_to_span
 
 from dotenv import load_dotenv
 
@@ -24,4 +26,5 @@ __all__ = [
     "get_samples_by_pattern",
     "group_by_template",
     "save_to_json",
+    "tag_to_span"
 ]

--- a/presidio_evaluator/tag_to_span.py
+++ b/presidio_evaluator/tag_to_span.py
@@ -1,0 +1,62 @@
+from typing import List, Optional
+from spacy.tokens import Doc
+
+from presidio_evaluator import Span
+
+
+def _to_io(tag):
+    if "-" in tag:
+        return tag[2:]
+    return tag
+
+
+def tag_to_span(tokens: Doc, tags: List[str]) -> List[Span]:
+    """
+    Transforms a list of tags to a list of spans, while ignoring labeling scheme.
+    :param tokens: List of spaCy tokens
+    :param tags: List of tags (e.g. ["O", "B-PER", "I-PER", "U-LOC"])
+    :return: List of spans
+    """
+
+    # If IO, translate to BIO for easier manipulation
+    not_io = any([tag[1] == "-" for tag in tags if len(tag) > 1])
+    if not_io:
+        tags = [_to_io(tag) for tag in tags]
+
+    if not len(tags):
+        return []
+
+    spans: List[Span] = []
+    prev_tag = "O"
+    prev_token = None
+    current_span: Optional[Span] = None
+    for token, tag in zip(tokens, tags):
+        if prev_tag != "O" and tag != prev_tag:
+            # end current before creating a new one
+            spans.append(current_span)
+            current_span = None
+
+        if tag != "O":
+            if prev_tag == "O" or prev_tag != tag:
+                # start new span as this tag is a new entity
+                current_span = Span(
+                    entity_type=tag,
+                    entity_value=str(token),
+                    start_position=token.idx,
+                    end_position=token.idx + len(token),
+                )
+            else:
+                # continue previous span
+                current_span.end_position = token.idx + len(token)
+                add_space = prev_token.idx + len(prev_token) < token.idx
+                current_span.entity_value += " " if add_space else ""
+                current_span.entity_value += str(token)
+
+        prev_tag = tag
+        prev_token = token
+
+    # Close span if it's still open
+    if prev_tag != "O" and current_span:
+        spans.append(current_span)
+
+    return spans

--- a/presidio_evaluator/tag_to_span.py
+++ b/presidio_evaluator/tag_to_span.py
@@ -18,13 +18,13 @@ def tag_to_span(tokens: Doc, tags: List[str]) -> List[Span]:
     :return: List of spans
     """
 
-    # If IO, translate to BIO for easier manipulation
+    if not len(tags):
+        return []
+
+    # If not IO, translate to IO for easier manipulation
     not_io = any([tag[1] == "-" for tag in tags if len(tag) > 1])
     if not_io:
         tags = [_to_io(tag) for tag in tags]
-
-    if not len(tags):
-        return []
 
     spans: List[Span] = []
     prev_tag = "O"

--- a/tests/test_tag_to_span.py
+++ b/tests/test_tag_to_span.py
@@ -1,0 +1,46 @@
+import pytest
+import spacy
+
+from presidio_evaluator import tag_to_span
+
+
+@pytest.fixture()
+def spacy_en_core_web_sm():
+    return spacy.load("en_core_web_sm")
+
+
+@pytest.mark.parametrize(
+    "text, tags, ents",
+    [
+        ("Dan  is my name. ", ["B-name", "O", "O", "O", "O"], [[0, 1, "name"]]),
+        ("Dan Brown lives here", ["B-name", "I-name", "O", "O", "O"], [[0, 2, "name"]]),
+        ("Dan Dan Dan", ["B-name", "B-name", "B-name"], [[0, 3, "name"]]),
+        ("Nothing to look for", ["O", "O", "O", "O"], []),
+        ("It's Dan", ["O", "O", "B-name"], [[2, 3, "name"]]),  # BIO tagging scheme
+        ("It's Dan", ["O", "O", "name"], [[2, 3, "name"]]),  # IO tagging scheme
+        ("It's Dan", ["O", "O", "B-name"], [[2, 3, "name"]]),  # wrong tagging scheme
+        (
+            "It's Dan Washington",
+            ["O", "O", "U-name", "U-loc"],
+            [[2, 3, "name"], [3, 4, "loc"]],
+        ),
+        (
+            "Dan is Washington",
+            ["U-name", "O", "U-loc"],
+            [[0, 1, "name"], [2, 3, "loc"]],
+        ),
+    ],
+)
+def test_tag_to_span(spacy_en_core_web_sm, text, tags, ents):
+    doc = spacy_en_core_web_sm(text)
+    spacy_ents = [spacy.tokens.Span(doc, ent[0], ent[1], label=ent[2]) for ent in ents]
+    doc.ents = spacy_ents
+
+    spans = tag_to_span(doc, tags)
+
+    assert len(spans) == len(ents)
+    for span, spacy_span in zip(spans, spacy_ents):
+        assert span.start_position == spacy_span.start_char
+        assert span.end_position == spacy_span.end_char
+        assert span.entity_type == spacy_span.label_
+        assert span.entity_value == str(spacy_span)


### PR DESCRIPTION
Helper method to perform tag labeling to span labeling (opposite of `span_to_tag` for cases where models return tags but we want to calculate span based metrics. 