### PR TITLE
Rename UsDriverLicenseProvider.driver_license to us_driver_license

### DIFF
--- a/presidio_evaluator/data_generator/faker_extensions/providers.py
+++ b/presidio_evaluator/data_generator/faker_extensions/providers.py
@@ -77,7 +77,7 @@ class UsDriverLicenseProvider(BaseProvider):
         formats = yaml.safe_load(open(us_driver_license_file))
         self.formats = formats['en']['faker']['driving_license']['usa']
 
-    def driver_license(self) -> str:
+    def us_driver_license(self) -> str:
         # US driver's licenses patterns vary by state. Here we sample a random state and format
         us_state = random.choice(list(self.formats))
         us_state_format = random.choice(self.formats[us_state])


### PR DESCRIPTION
As mentioned in Issue https://github.com/microsoft/presidio-research/issues/83 data_generator.generate_fake_data fails to generate data with
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File [~/.pyenv/versions/3.11.6/envs/piidetection/lib/python3.11/site-packages/faker/generator.py:92](https://file+.vscode-resource.vscode-cdn.net/Users/gustav.vonzitzewitz/workspace/buzok_experiments/PII_detection/presidio/~/.pyenv/versions/3.11.6/envs/piidetection/lib/python3.11/site-packages/faker/generator.py:92), in Generator.get_formatter(self, formatter)
...
AttributeError: 'RecordGenerator' object has no attribute 'us_driver_license'
...
AttributeError: Failed to generate fake data based on template "My driver's license number is {{us_driver_license}}
".You might need to add a new Faker provider! Unknown formatter 'us_driver_license'
```
Renaming the provider method from `driver_license` to `us_driver_license` fixes the issue