### PR TITLE
Add a results DF to the evaluator result

### DIFF
--- a/presidio_evaluator/data_objects.py
+++ b/presidio_evaluator/data_objects.py
@@ -114,7 +114,7 @@ class InputSample(object):
         tags: Optional[List[str]] = None,
         create_tags_from_span=False,
         token_model_version="en_core_web_sm",
-        scheme="IO",
+        scheme:str="IO",
         metadata: Dict = None,
         sample_id: int = None,
         template_id: int = None,

--- a/presidio_evaluator/evaluation/evaluation_result.py
+++ b/presidio_evaluator/evaluation/evaluation_result.py
@@ -20,6 +20,9 @@ class EvaluationResult:
         entity_recall_dict: Optional[Dict[str, float]] = None,
         entity_precision_dict: Optional[Dict[str, float]] = None,
         n_dict: Optional[Dict[str, int]] = None,
+        tokens: Optional[List[str]] = None,
+        actual_tags: Optional[List[str]] = None,
+        predicted_tags: Optional[List[str]] = None
     ):
         """
         Holds the output of a comparison between ground truth and predicted
@@ -34,6 +37,9 @@ class EvaluationResult:
         :param entity_recall_dict: Recall per entity
         :param entity_precision_dict: Precision per entity
         :param n_dict: Number of tokens per entity
+        :param tokens: List of tokens
+        :param actual_tags: List of actual tags
+        :param predicted_tags: List of predicted tags
         """
 
         self.results = results
@@ -49,6 +55,9 @@ class EvaluationResult:
             entity_precision_dict if entity_precision_dict else {}
         )
         self.n_dict = n_dict if n_dict else {}
+        self.tokens = tokens
+        self.actual_tags = actual_tags
+        self.predicted_tags = predicted_tags
 
     def __str__(self):
         return_str = ""

--- a/presidio_evaluator/evaluation/evaluator.py
+++ b/presidio_evaluator/evaluation/evaluator.py
@@ -422,6 +422,10 @@ class Evaluator:
         - prediction
         """
 
+        if not results or not results[0].tokens:
+            raise ValueError("Results should not be empty and should contain tokens for the evaluation."
+                             "Make sure the input samples have tokens.")
+
         rows_list = []
         for i, res in enumerate(results):
             tokens = res.tokens

--- a/presidio_evaluator/evaluation/evaluator.py
+++ b/presidio_evaluator/evaluation/evaluator.py
@@ -412,7 +412,7 @@ class Evaluator:
         return evaluation_result
 
     @staticmethod
-    def get_results_dataframe(results: List[EvaluationResult]) -> pd.DataFrame:
+    def get_results_dataframe(evaluation_results: List[EvaluationResult]) -> pd.DataFrame:
         """Return a DataFrame with the results of the evaluation.
 
         Columns:
@@ -422,12 +422,12 @@ class Evaluator:
         - prediction
         """
 
-        if not results or not results[0].tokens:
-            raise ValueError("Results should not be empty and should contain tokens for the evaluation."
-                             "Make sure the input samples have tokens.")
+        if not evaluation_results or not evaluation_results[0].tokens:
+            raise ValueError("The evaluation results should not be empty and must contain tokens. "
+                             "Ensure that the input samples have tokens.")
 
         rows_list = []
-        for i, res in enumerate(results):
+        for i, res in enumerate(evaluation_results):
             tokens = res.tokens
             annotations = res.actual_tags
             predictions = res.predicted_tags

--- a/presidio_evaluator/models/base_model.py
+++ b/presidio_evaluator/models/base_model.py
@@ -8,7 +8,7 @@ from presidio_evaluator import InputSample, io_to_scheme
 class BaseModel(ABC):
     def __init__(
         self,
-        labeling_scheme: str = "BIO",
+        labeling_scheme: str = "IO",
         entities_to_keep: List[str] = None,
         entity_mapping: Optional[Dict[str, str]] = None,
         verbose: bool = False,

--- a/presidio_evaluator/models/presidio_analyzer_wrapper.py
+++ b/presidio_evaluator/models/presidio_analyzer_wrapper.py
@@ -39,8 +39,7 @@ class PresidioAnalyzerWrapper(BaseModel):
         values should be the model's supported entity types.
         :param ad_hoc_recognizers: List of ad-hoc recognizers to be used in the analyze method
         :param context: List of context words to be passed to the analyze method
-        :param allow_list: List of allowed values to be passed toe the analyze method
-
+        :param allow_list: List of allowed values to be passed to the analyze method
         """
         super().__init__(
             entities_to_keep=entities_to_keep,

--- a/presidio_evaluator/models/presidio_analyzer_wrapper.py
+++ b/presidio_evaluator/models/presidio_analyzer_wrapper.py
@@ -17,7 +17,7 @@ class PresidioAnalyzerWrapper(BaseModel):
         analyzer_engine: Optional[AnalyzerEngine] = None,
         entities_to_keep: List[str] = None,
         verbose: bool = False,
-        labeling_scheme: str = "BIO",
+        labeling_scheme: str = "IO",
         score_threshold: float = 0.4,
         language: str = "en",
         entity_mapping: Optional[Dict[str, str]] = None,
@@ -28,6 +28,19 @@ class PresidioAnalyzerWrapper(BaseModel):
         """
         Evaluation wrapper for the Presidio Analyzer
         :param analyzer_engine: object of type AnalyzerEngine (from presidio-analyzer)
+        :param entities_to_keep: Which entities should be evaluated? if None, all are kept
+        :param verbose: Whether to print more debug info
+        :param labeling_scheme: Used to translate (if needed)
+        the prediction to a specific scheme (IO, BIO/IOB, BILUO)
+        :param score_threshold: Minimum score for an entity to be considered
+        :param language: Language of the text
+        :param entity_mapping: Dictionary for mapping this model's input and output with the expected.
+        Keys should be the input entity types (from the input dataset),
+        values should be the model's supported entity types.
+        :param ad_hoc_recognizers: List of ad-hoc recognizers to be used in the analyze method
+        :param context: List of context words to be passed to the analyze method
+        :param allow_list: List of allowed values to be passed toe the analyze method
+
         """
         super().__init__(
             entities_to_keep=entities_to_keep,

--- a/presidio_evaluator/models/presidio_recognizer_wrapper.py
+++ b/presidio_evaluator/models/presidio_recognizer_wrapper.py
@@ -69,7 +69,7 @@ class PresidioRecognizerWrapper(BaseModel):
             tags.append(res.entity_type)
             scores.append(res.score)
         response_tags = span_to_tag(
-            scheme="IO",
+            scheme=self.labeling_scheme,
             text=sample.full_text,
             starts=starts,
             ends=ends,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ plotly= "^5.24.0"
 optional=true
 
 [tool.poetry.group.ner.dependencies]
-flair = "^0.14.0"
+flair = "^0.15.1"
 spacy_stanza = "^1.0.0"
 spacy_huggingface_pipelines = "^0.0.4"
 azure-ai-textanalytics = "^5.3.0"

--- a/tests/integration/test_notebook.py
+++ b/tests/integration/test_notebook.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+from pprint import pprint
+from collections import Counter
+from typing import Dict, List
+import json
+
+from presidio_evaluator import InputSample
+from presidio_evaluator.evaluation import Evaluator, ModelError, Plotter
+from presidio_evaluator.experiment_tracking import get_experiment_tracker
+from presidio_evaluator.models import PresidioAnalyzerWrapper
+
+
+def test_notebook():
+    test_dir = Path(__file__).parent  # Get the directory of this test file
+    data_path = test_dir.parent / "data" / "generated_small.json"
+    dataset = InputSample.read_dataset_json(data_path)
+    print(len(dataset))
+
+    def get_entity_counts(dataset: List[InputSample]) -> Dict:
+        """Return a dictionary with counter per entity type."""
+        entity_counter = Counter()
+        for sample in dataset:
+            for tag in sample.tags:
+                entity_counter[tag] += 1
+        return entity_counter
+
+    entity_counts = get_entity_counts(dataset)
+    print("Count per entity:")
+    pprint(entity_counts.most_common(), compact=True)
+
+    print(
+        "\nMin and max number of tokens in dataset: "
+        f"Min: {min([len(sample.tokens) for sample in dataset])}, "
+        f"Max: {max([len(sample.tokens) for sample in dataset])}"
+    )
+
+    print(
+        f"Min and max sentence length in dataset: "
+        f"Min: {min([len(sample.full_text) for sample in dataset])}, "
+        f"Max: {max([len(sample.full_text) for sample in dataset])}"
+    )
+
+    print("\nExample InputSample:")
+    print(dataset[0])
+
+    print("A few examples sentences containing each entity:\n")
+    for entity in entity_counts.keys():
+        samples = [sample for sample in dataset if entity in set(sample.tags)]
+        if len(samples) > 1 and entity != "O":
+            print(
+                f"Entity: <{entity}> two example sentences:\n"
+                f"\n1) {samples[0].full_text}"
+                f"\n2) {samples[1].full_text}"
+                f"\n------------------------------------\n"
+            )
+
+    from presidio_analyzer import AnalyzerEngine
+
+    # Loading the vanilla Analyzer Engine, with the default NER model.
+    analyzer_engine = AnalyzerEngine(default_score_threshold=0.4)
+
+    pprint("Supported entities for English:")
+    pprint(analyzer_engine.get_supported_entities("en"), compact=True)
+
+    print("\nLoaded recognizers for English:")
+    pprint(
+        [
+            rec.name
+            for rec in analyzer_engine.registry.get_recognizers("en", all_fields=True)
+        ],
+        compact=True,
+    )
+
+    print("\nLoaded NER models:")
+    pprint(analyzer_engine.nlp_engine.models)
+
+    entities_mapping = PresidioAnalyzerWrapper.presidio_entities_map  # default mapping
+
+    print("Using this mapping between the dataset and Presidio's entities:")
+    pprint(entities_mapping, compact=True)
+
+    dataset = Evaluator.align_entity_types(
+        dataset, entities_mapping=entities_mapping, allow_missing_mappings=True
+    )
+    new_entity_counts = get_entity_counts(dataset)
+    print("\nCount per entity after alignment:")
+    pprint(new_entity_counts.most_common(), compact=True)
+
+    dataset_entities = list(new_entity_counts.values())
+
+    # ## 5. Set up the Evaluator object
+
+    # In[8]:
+
+    # Set up the experiment tracker to log the experiment for reproducibility
+    experiment = get_experiment_tracker()
+
+    # Create the evaluator object
+    evaluator = Evaluator(model=analyzer_engine)
+
+    evaluation_results = evaluator.evaluate_all(dataset)
+    results = evaluator.calculate_score(evaluation_results)
+
+    results_df = evaluator.get_results_dataframe(evaluation_results)
+    print(results_df)
+
+    experiment.log_metrics(results.to_log())
+    entities, confmatrix = results.to_confusion_matrix()
+    experiment.log_confusion_matrix(matrix=confmatrix, labels=entities)
+
+    # Track model and dataset params
+    params = {"dataset_name": data_path, "model_name": evaluator.model.name}
+    params.update(evaluator.model.to_log())
+    experiment.log_parameters(params)
+    experiment.log_dataset_hash(dataset)
+    experiment.log_parameter("entity_mappings", json.dumps(entities_mapping))
+
+    # Plot output
+    plotter = Plotter(
+        results=results, output_folder="plots", model_name=evaluator.model.name, beta=2
+    )
+
+    # plotter.plot_scores()
+
+    # In[12]:
+
+    pprint(
+        {
+            "PII F": results.pii_f,
+            "PII recall": results.pii_recall,
+            "PII precision": results.pii_precision,
+        }
+    )
+
+    # plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix )
+
+    # In[14]:
+
+    # plotter.plot_most_common_tokens()
+
+    # ### 7a. False positives
+    # #### Most common false positive tokens:
+
+    # In[15]:
+
+    ModelError.most_common_fp_tokens(results.model_errors)
+
+    # #### More FP analysis
+
+    # In[16]:
+
+    fps_df = ModelError.get_fps_dataframe(results.model_errors, entity=["PERSON"])
+    fps_df[["full_text", "token", "annotation", "prediction"]].head(20)
+
+    # ### 7b. False negatives (FN)
+    #
+    # #### Most common false negative examples + a few samples with FN
+
+    # In[17]:
+
+    ModelError.most_common_fn_tokens(results.model_errors, n=15)
+
+    # #### More FN analysis
+
+    # In[18]:
+
+    fns_df = ModelError.get_fns_dataframe(results.model_errors, entity=["PHONE_NUMBER"])
+
+    # In[19]:
+
+    fns_df[["full_text", "token", "annotation", "prediction"]].head(20)

--- a/tests/test_data_objects.py
+++ b/tests/test_data_objects.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from copy import deepcopy
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -493,8 +493,6 @@ def test_results_to_dataframe():
     tags = ["PERSON", "O", "EMAIL", "PHONE", "O"]
     evaluator = Evaluator(model=MockTokensModel(prediction))
 
-    # Ground truth: [PERSON, O, EMAIL, PHONE, O]
-    # Prediction:   [PERSON, EMAIL, PHONE, LOCATION, PERSON]
     sample = InputSample(
         full_text="John details john@mail.com 123-456-7890 today",
         tokens=tokens,

--- a/tests/test_presidio_pseudonymize.py
+++ b/tests/test_presidio_pseudonymize.py
@@ -1,5 +1,4 @@
 import pytest
-from faker import Faker
 from faker.providers import DynamicProvider
 from presidio_analyzer import RecognizerResult
 

--- a/tests/test_span_generator.py
+++ b/tests/test_span_generator.py
@@ -122,7 +122,7 @@ def test_without_spans(span_faker):
     expected = "this is a sentence with bar"
     res = span_faker.parse(pattern)
 
-    assert type(res) == str
+    assert type(res) is str
     assert res == expected
 
 


### PR DESCRIPTION
- Added three values to the `EvaluationResult` object: token, tag, prediction
- Added a `get_results_dataframe` method to the `Evaluator` class, which returns a data frame with the sentence_id, token, tag, prediction, to be used for other types of analysis or evaluations.

Example usage:
```py
evaluator = Evaluator(model=analyzer_engine)
evaluation_results = evaluator.evaluate_all(dataset)

results_df = evaluator.get_results_dataframe(evaluation_results)

```

```
    sentence_id    token    annotation prediction
0             0   Please             O          O
1             0     have             O          O
2             0      the             O          O
3             0  manager             O          O
4             0     call             O          O
5             0       me             O          O
6             0       at             O          O
7             0        (  PHONE_NUMBER          O
8             0       96  PHONE_NUMBER          PHONE_NUMBER
9             0        )  PHONE_NUMBER          PHONE_NUMBER
10            0      627  PHONE_NUMBER          PHONE_NUMBER
11            0        -  PHONE_NUMBER          PHONE_NUMBER
12            0      277  PHONE_NUMBER          PHONE_NUMBER
```