### PR TITLE
fix: support non-en usage of evaluator with analyzer_engine

### DIFF
--- a/presidio_evaluator/evaluation/evaluator.py
+++ b/presidio_evaluator/evaluation/evaluator.py
@@ -22,6 +22,7 @@ class Evaluator:
         entities_to_keep: Optional[List[str]] = None,
         generic_entities: Optional[List[str]] = None,
         skip_words: Optional[List] = None,
+        language: str = "en",
     ):
         """
         Evaluate a PII detection model or a Presidio analyzer / recognizer
@@ -38,7 +39,7 @@ class Evaluator:
         :param skip_words: List of words to skip. If None, the default list would be used.
         """
         if isinstance(model, AnalyzerEngine):
-            self.model = PresidioAnalyzerWrapper(analyzer_engine=model)
+            self.model = PresidioAnalyzerWrapper(analyzer_engine=model, language=language)
         elif isinstance(model, BaseModel):
             self.model = model
         else:


### PR DESCRIPTION
Hi,

This simple PR may or may not actually be a breaking change due to the newly added default kwarg of language. It is required, however, by non-en usages. 🙏