### PR TITLE
spacy and faker dependency updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ include = [{ path= "presidio_evaluator/data_generator/raw_data/*"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-spacy = "<=3.8.3"
+spacy = { version = "<3.8.4", python = "<3.10" }  #Remove once 3.9 is EOL
 numpy = "^2.0.0"
 pandas = "^2.1.4"
 tqdm = "^4.60.0"
-faker = "^21.0"
+faker = "*"
 scikit-learn = "^1.3.2"
 presidio-analyzer = "^2.2.351"
 presidio-anonymizer = "^2.2.351"


### PR DESCRIPTION
Updated Faker dependency to be unbounded (as major versions move quickly)
Updated spacy to be limited to <3.8.4 only for python 3.9

Fixes #134 