### PR TITLE
Added start_indices to dataframe

### DIFF
--- a/presidio_evaluator/evaluation/evaluation_result.py
+++ b/presidio_evaluator/evaluation/evaluation_result.py
@@ -22,7 +22,8 @@ class EvaluationResult:
         n_dict: Optional[Dict[str, int]] = None,
         tokens: Optional[List[str]] = None,
         actual_tags: Optional[List[str]] = None,
-        predicted_tags: Optional[List[str]] = None
+        predicted_tags: Optional[List[str]] = None,
+        start_indices: List[bool] = None
     ):
         """
         Holds the output of a comparison between ground truth and predicted
@@ -40,6 +41,8 @@ class EvaluationResult:
         :param tokens: List of tokens
         :param actual_tags: List of actual tags
         :param predicted_tags: List of predicted tags
+        :param start_indices: List of boolean values indicating if
+        the token is a start token of an entity
         """
 
         self.results = results
@@ -58,6 +61,7 @@ class EvaluationResult:
         self.tokens = tokens
         self.actual_tags = actual_tags
         self.predicted_tags = predicted_tags
+        self.start_indices = start_indices
 
     def __str__(self):
         return_str = ""

--- a/presidio_evaluator/evaluation/evaluation_result.py
+++ b/presidio_evaluator/evaluation/evaluation_result.py
@@ -61,7 +61,7 @@ class EvaluationResult:
         self.tokens = tokens
         self.actual_tags = actual_tags
         self.predicted_tags = predicted_tags
-        self.start_indices = start_indices
+        self.start_indices = start_indices if start_indices is not None else []
 
     def __str__(self):
         return_str = ""

--- a/presidio_evaluator/evaluation/evaluator.py
+++ b/presidio_evaluator/evaluation/evaluator.py
@@ -210,6 +210,7 @@ class Evaluator:
             tokens=[str(token) for token in sample.tokens],
             actual_tags=sample.tags,
             predicted_tags=prediction,
+            start_indices=sample.start_indices,
         )
 
     def evaluate_all(
@@ -420,6 +421,7 @@ class Evaluator:
         - token text
         - annotation
         - prediction
+        - start_indices
         """
 
         if not evaluation_results or not evaluation_results[0].tokens:
@@ -431,11 +433,13 @@ class Evaluator:
             tokens = res.tokens
             annotations = res.actual_tags
             predictions = res.predicted_tags
+            start_indices = res.start_indices
             for j in range(len(tokens)):
                 rows_list.append({"sentence_id": i,
                                   "token": tokens[j],
                                   "annotation": annotations[j],
-                                  "prediction": predictions[j]})
+                                  "prediction": predictions[j],
+                                  "start_indices": start_indices[j]})
 
         results_df = pd.DataFrame(rows_list)
         return results_df

--- a/tests/test_data_objects.py
+++ b/tests/test_data_objects.py
@@ -167,3 +167,86 @@ def test_spans_intersection(
 
     intersection = span1.intersect(span2, ignore_entity_type=ignore_entity_type)
     assert intersection == intersection_length
+
+
+def test_start_indices_in_get_tags():
+    """Test that start_indices are correctly generated when using get_tags"""
+    sample = InputSample(
+        full_text="Dan Smith is my friend from Tel Aviv.",
+        spans=[
+            Span(entity_type="PERSON", entity_value="Dan Smith", start_position=0, end_position=9),
+            Span(entity_type="LOCATION", entity_value="Tel Aviv", start_position=28, end_position=36)
+        ]
+    )
+
+    tokens, tags, start_indices = sample.get_tags(scheme="IO")
+
+    # Verify tokens align with start_indices
+    assert len(tokens) == len(start_indices)
+
+    # "Dan" should be marked as start since it's the beginning of "Dan Smith"
+    assert tokens[0].text == "Dan"
+    assert start_indices[0] is True
+
+    # Other tokens in the "Dan Smith" entity should not be marked as start
+    assert tokens[1].text == "Smith"
+    assert start_indices[1] is False
+
+    # "Tel" should be marked as start since it's the beginning of "Tel Aviv"
+    assert tokens[6].text == "Tel"
+    assert start_indices[6] is True
+
+    # "Aviv" should not be marked as start
+    assert tokens[7].text == "Aviv"
+    assert start_indices[7] is False
+
+    # Non-entity tokens should be False
+    assert all(not start_indices[i] for i in [2, 3, 4, 5, 8])
+
+
+def test_start_indices_in_create_tags_from_span():
+    """Test that start_indices are correctly set when using create_tags_from_span=True"""
+    sample = InputSample(
+        full_text="John works at Microsoft.",
+        spans=[
+            Span(entity_type="PERSON", entity_value="John", start_position=0, end_position=4),
+            Span(entity_type="ORG", entity_value="Microsoft", start_position=14, end_position=23)
+        ],
+        create_tags_from_span=True
+    )
+
+    # Verify start_indices are set correctly
+    assert len(sample.tokens) == len(sample.start_indices)
+
+    # "John" should be marked as start
+    assert sample.tokens[0].text == "John"
+    assert sample.start_indices[0] is True
+
+    # "Microsoft" should be marked as start
+    assert sample.tokens[3].text == "Microsoft"
+    assert sample.start_indices[3] is True
+
+    # Non-entity tokens should be False
+    assert all(not sample.start_indices[i] for i in [1, 2, 4])
+
+
+def test_manually_set_start_indices():
+    """Test manually setting start_indices during initialization"""
+    sample = InputSample(
+        full_text="Alex and Bob are friends.",
+        spans=[
+            Span(entity_type="PERSON", entity_value="Alex", start_position=0, end_position=4),
+            Span(entity_type="PERSON", entity_value="Bob", start_position=9, end_position=12)
+        ],
+        start_indices=[True, False, True, False, False]
+    )
+
+    assert sample.start_indices == [True, False, True, False, False]
+
+    # When creating tags from spans, the start_indices should be updated
+    sample.get_tags()
+
+    # After updating, "Alex" and "Bob" should be marked as start tokens
+    assert sample.start_indices[0] is True  # Alex
+    assert sample.start_indices[2] is True  # Bob
+    assert all(not sample.start_indices[i] for i in [1, 3, 4])  # Other tokens

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -491,11 +491,13 @@ def test_results_to_dataframe():
     prediction = ["O", "EMAIL", "PHONE", "LOCATION", "PERSON"]
     tokens = ["John", "details", "john@mail.com", "123-456-7890", "today"]
     tags = ["PERSON", "O", "EMAIL", "PHONE", "O"]
+    start_indices = [True, False, True, True, False]
     evaluator = Evaluator(model=MockTokensModel(prediction))
 
     sample = InputSample(
         full_text="John details john@mail.com 123-456-7890 today",
         tokens=tokens,
+        start_indices=start_indices,
         tags=tags
     )
 
@@ -510,6 +512,7 @@ def test_results_to_dataframe():
     assert df["prediction"].to_list() == prediction + prediction
     assert df["token"].to_list() == tokens + tokens
     assert df["sentence_id"].to_list() == [0]*len(tokens) + [1]*len(tokens)
+    assert df["start_indices"].to_list() == start_indices + start_indices
 
 
 def test_score_calculation():


### PR DESCRIPTION
Added a new parameter, `start_indices` which stores "True" for each token index that contains the start of an entity. This is useful for span reconstruction or for IO to BIO/BILUO conversion.