### PR TITLE
Negruber1/issues 128 130

### DIFF
--- a/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
+++ b/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
@@ -658,8 +658,7 @@
     "                                labels=entities)\n",
     "\n",
     "# end experiment\n",
-    "output_dir = Path(Path.cwd().parent, \"run_experiment_output\")\n",
-    "experiment.end(output_dir=output_dir)"
+    "experiment.end()"
    ]
   },
   {

--- a/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
+++ b/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
@@ -622,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "cf65af8f",
    "metadata": {
     "ExecuteTime": {
@@ -658,7 +658,8 @@
     "                                labels=entities)\n",
     "\n",
     "# end experiment\n",
-    "experiment.end()"
+    "output_dir = Path(Path.cwd().parent, \"run_experiment_output\")\n",
+    "experiment.end(output_dir=output_dir)"
    ]
   },
   {
@@ -671,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "5b4d662d-596c-4a69-b3c9-1edcda20cc5b",
    "metadata": {
     "ExecuteTime": {
@@ -705,13 +706,13 @@
    "source": [
     "# Plot output\n",
     "plotter = Plotter(results=results, \n",
-    "                  output_folder = \"plots\",\n",
     "                  model_name = evaluator.model.name, \n",
     "                  save_as=\"png\",\n",
     "                  beta = 2) \n",
     "\n",
-    "\n",
-    "plotter.plot_scores()"
+    "# Path of the directory to save the plots\n",
+    "output_folder = Path(Path.cwd().parent, \"plotter_output\")\n",
+    "plotter.plot_scores(output_folder)"
    ]
   },
   {
@@ -750,7 +751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "cfe3b38d440148cf",
    "metadata": {
     "ExecuteTime": {
@@ -768,12 +769,12 @@
     }
    ],
    "source": [
-    "plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix)"
+    "plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix, output_folder=output_folder)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "a408f03e-a014-4631-923f-00cc9d6e08e7",
    "metadata": {},
    "outputs": [
@@ -793,7 +794,7 @@
     }
    ],
    "source": [
-    "plotter.plot_most_common_tokens()"
+    "plotter.plot_most_common_tokens(output_folder)"
    ]
   },
   {

--- a/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
+++ b/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
@@ -693,7 +693,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "cf65af8f",
    "metadata": {
     "ExecuteTime": {
@@ -729,7 +729,8 @@
     "                                labels=entities)\n",
     "\n",
     "# end experiment\n",
-    "experiment.end()\n",
+    "output_dir=Path(Path.cwd().parent, \"data\", \"run_experiment_output\")\n",
+    "experiment.end(output_dir=output_dir)\n",
     "\n",
     "# Note that the experiment params and metrics are saved locally"
    ]
@@ -781,7 +782,6 @@
     "                  model_name = evaluator.model.name, \n",
     "                  #save_as=\"png\",\n",
     "                  beta = 2) \n",
-    "\n",
     "plotter.plot_scores()"
    ]
   },
@@ -822,7 +822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "9a352c1c-4f4f-4fea-b947-1963e29e6f1e",
    "metadata": {},
    "outputs": [
@@ -835,8 +835,7 @@
     }
    ],
    "source": [
-    "plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix)\n",
-    "#plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix, save_as=\"png\")"
+    "plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix)"
    ]
   },
   {

--- a/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
+++ b/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
@@ -729,8 +729,7 @@
     "                                labels=entities)\n",
     "\n",
     "# end experiment\n",
-    "output_dir=Path(Path.cwd().parent, \"data\", \"run_experiment_output\")\n",
-    "experiment.end(output_dir=output_dir)\n",
+    "experiment.end()\n",
     "\n",
     "# Note that the experiment params and metrics are saved locally"
    ]
@@ -781,8 +780,9 @@
     "plotter = Plotter(results=results, \n",
     "                  model_name = evaluator.model.name, \n",
     "                  #save_as=\"png\",\n",
-    "                  beta = 2) \n",
-    "plotter.plot_scores()"
+    "                  beta = 2)\n",
+    "output_folder = Path(Path.cwd().parent, \"plotter_output\")\n",
+    "plotter.plot_scores(output_folder=output_folder)"
    ]
   },
   {
@@ -835,12 +835,12 @@
     }
    ],
    "source": [
-    "plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix)"
+    "plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix, output_folder=output_folder)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "cfe3b38d440148cf",
    "metadata": {
     "ExecuteTime": {
@@ -865,7 +865,7 @@
     }
    ],
    "source": [
-    "plotter.plot_most_common_tokens()"
+    "plotter.plot_most_common_tokens(output_folder=output_folder)"
    ]
   },
   {

--- a/presidio_evaluator/evaluation/plotter.py
+++ b/presidio_evaluator/evaluation/plotter.py
@@ -304,7 +304,7 @@ class Plotter:
     def save_fig_to_file(
         self,
         fig: Figure,
-        output_folder: Optional[Path] = None,
+        output_folder: Path,
         file_name: str = "figure",
     ) -> None:
         """

--- a/presidio_evaluator/evaluation/plotter.py
+++ b/presidio_evaluator/evaluation/plotter.py
@@ -87,10 +87,11 @@ class Plotter:
         recall_fig = self._plot_one_metric(df, metric="recall")
         precision_fig = self._plot_one_metric(df, metric="precision")
         figs = [beta_fig, recall_fig, precision_fig]
-
-        for fig in figs:
+        fig_names = ["f_beta", "recall", "precision"]
+        
+        for fig, file_name in zip(figs, fig_names):
             if output_folder is not None:
-                self.save_fig_to_file(fig=fig, output_folder=output_folder, file_name="scores")
+                self.save_fig_to_file(fig=fig, output_folder=output_folder, file_name=f"scores-{file_name}")
                 fig.show(self.save_as)
             else:
                 fig.show()
@@ -198,12 +199,13 @@ class Plotter:
             fp_fig = None
             print("No false positives found")
 
-        for fig in [fn_fig, fp_fig]:
+        fig_names = ["fn", "fp"]
+        for fig, fig_name in zip([fn_fig, fp_fig], fig_names):
             if not fig:
                 continue
 
             if output_folder is not None:
-                self.save_fig_to_file(fig=fig, output_folder=output_folder, file_name="common-errors")
+                self.save_fig_to_file(fig=fig, output_folder=output_folder, file_name=f"common-errors-{fig_name}")
                 fig.show(self.save_as)
             else:
                 fig.show()
@@ -312,9 +314,7 @@ class Plotter:
             output_folder (Path): The folder where the plot will be saved.
             file_name (str): The name of the file to save the plot as.
         """
-        if output_folder is not None:
-            if not output_folder.exists():  
-                output_folder.mkdir(parents=True, exist_ok=True)
-            fig.write_image(
-                Path(output_folder, f"{self.model_name}-{file_name}.{self.save_as}")
-            )
+        output_folder.mkdir(parents=True, exist_ok=True)
+        fig.write_image(
+            Path(output_folder, f"{self.model_name}-{file_name}.{self.save_as}")
+        )

--- a/presidio_evaluator/evaluation/plotter.py
+++ b/presidio_evaluator/evaluation/plotter.py
@@ -29,7 +29,8 @@ class Plotter:
                       weight of precision vs. recall.
         save_as (Optional[str]): The file format to save plots (e.g., "png", "svg").
                                  If specified, plots are saved in the given format.
-                                 If not specified, plots are saved in png format
+                                 It has to be specified if output_folder is passed 
+                                 as input to the plotting functions.
 
     Notes:
         - plots are always displayed interactively using the default
@@ -43,7 +44,7 @@ class Plotter:
         results: EvaluationResult,
         model_name: str = "PresidioAnalyzerWrapper",
         beta: float = 2,
-        save_as: Optional[str] = "png",
+        save_as: Optional[str] = None,
     ):
         self.results = results
         self.save_as = save_as
@@ -92,7 +93,7 @@ class Plotter:
         for fig, file_name in zip(figs, fig_names):
             if output_folder is not None:
                 self.save_fig_to_file(fig=fig, output_folder=output_folder, file_name=f"scores-{file_name}")
-                fig.show(self.save_as)
+                fig.show()
             else:
                 fig.show()
 
@@ -206,7 +207,7 @@ class Plotter:
 
             if output_folder is not None:
                 self.save_fig_to_file(fig=fig, output_folder=output_folder, file_name=f"common-errors-{fig_name}")
-                fig.show(self.save_as)
+                fig.show()
             else:
                 fig.show()
 
@@ -315,6 +316,15 @@ class Plotter:
             file_name (str): The name of the file to save the plot as.
         """
         output_folder.mkdir(parents=True, exist_ok=True)
-        fig.write_image(
-            Path(output_folder, f"{self.model_name}-{file_name}.{self.save_as}")
-        )
+        if self.save_as == "html":
+            fig.write_html(
+                Path(output_folder, f"{self.model_name}-{file_name}.{self.save_as}")
+            )
+        elif self.save_as is not None:
+            fig.write_image(
+                Path(output_folder, f"{self.model_name}-{file_name}.{self.save_as}")
+            )
+        else:
+            raise ValueError(
+                "save_as must be either 'html' or a valid image format (e.g., 'png', 'svg')."
+            )

--- a/presidio_evaluator/experiment_tracking/experiment_tracker.py
+++ b/presidio_evaluator/experiment_tracking/experiment_tracker.py
@@ -12,6 +12,7 @@ class ExperimentTracker:
         self.dataset_info = None
         self.confusion_matrix = None
         self.labels = None
+        self.output_dir = Path.cwd()
 
     def log_parameter(self, key: str, value: object):
         self.parameters[key] = value
@@ -30,6 +31,9 @@ class ExperimentTracker:
     def log_dataset_hash(self, data: str):
         pass
 
+    def log_output_dir(self, path: str):
+        self.output_dir = Path(path)
+
     def log_dataset_info(self, name: str):
         self.dataset_info = name
 
@@ -47,21 +51,15 @@ class ExperimentTracker:
     def start(self):
         pass
 
-    def end(self, output_dir: Union[str, Path] = None):
+    def end(self):
         datetime_val = time.strftime("%Y%m%d-%H%M%S")
         filename = f"experiment_{datetime_val}.json"
         
-        # Convert to Path object if string
-        if isinstance(output_dir, str):
-            output_dir = Path(output_dir)
-        elif output_dir is None:
-            output_dir = Path.cwd()
-            
         # Ensure output directory exists
-        output_dir.mkdir(parents=True, exist_ok=True)
-            
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
         # Create full file path using proper path joining
-        output_path = output_dir / filename
+        output_path = self.output_dir / filename
         print(f"saving experiment data to {output_path}")
         
         with open(output_path, 'w') as json_file:

--- a/presidio_evaluator/experiment_tracking/experiment_tracker.py
+++ b/presidio_evaluator/experiment_tracking/experiment_tracker.py
@@ -31,9 +31,6 @@ class ExperimentTracker:
     def log_dataset_hash(self, data: str):
         pass
 
-    def log_output_dir(self, path: str):
-        self.output_dir = Path(path)
-
     def log_dataset_info(self, name: str):
         self.dataset_info = name
 

--- a/presidio_evaluator/experiment_tracking/experiment_tracker.py
+++ b/presidio_evaluator/experiment_tracking/experiment_tracker.py
@@ -45,9 +45,9 @@ class ExperimentTracker:
     def start(self):
         pass
 
-    def end(self):
+    def end(self, output_dir: str = None):
         datetime_val = time.strftime("%Y%m%d-%H%M%S")
         filename = f"experiment_{datetime_val}.json"
-        print(f"saving experiment data to {filename}")
-        with open(filename, 'w') as json_file:
+        print(f"saving experiment data to {output_dir}{filename}")
+        with open(f"{output_dir}{filename}", 'w') as json_file:
             json.dump(self.__dict__, json_file)

--- a/presidio_evaluator/experiment_tracking/experiment_tracker.py
+++ b/presidio_evaluator/experiment_tracking/experiment_tracker.py
@@ -1,6 +1,8 @@
 import json
 import time
-from typing import Dict, List
+import os
+from pathlib import Path
+from typing import Dict, List, Union
 
 
 class ExperimentTracker:
@@ -45,9 +47,22 @@ class ExperimentTracker:
     def start(self):
         pass
 
-    def end(self, output_dir: str = None):
+    def end(self, output_dir: Union[str, Path] = None):
         datetime_val = time.strftime("%Y%m%d-%H%M%S")
         filename = f"experiment_{datetime_val}.json"
-        print(f"saving experiment data to {output_dir}{filename}")
-        with open(f"{output_dir}{filename}", 'w') as json_file:
+        
+        # Convert to Path object if string
+        if isinstance(output_dir, str):
+            output_dir = Path(output_dir)
+        elif output_dir is None:
+            output_dir = Path.cwd()
+            
+        # Ensure output directory exists
+        output_dir.mkdir(parents=True, exist_ok=True)
+            
+        # Create full file path using proper path joining
+        output_path = output_dir / filename
+        print(f"saving experiment data to {output_path}")
+        
+        with open(output_path, 'w') as json_file:
             json.dump(self.__dict__, json_file)

--- a/tests/integration/test_notebook.py
+++ b/tests/integration/test_notebook.py
@@ -117,7 +117,7 @@ def test_notebook():
 
     # Plot output
     plotter = Plotter(
-        results=results, output_folder="plots", model_name=evaluator.model.name, beta=2
+        results=results, model_name=evaluator.model.name, beta=2
     )
 
     # plotter.plot_scores()

--- a/tests/integration/test_notebook.py
+++ b/tests/integration/test_notebook.py
@@ -116,9 +116,9 @@ def test_notebook():
     experiment.log_parameter("entity_mappings", json.dumps(entities_mapping))
 
     # Plot output
-    plotter = Plotter(
-        results=results, model_name=evaluator.model.name, beta=2
-    )
+    # plotter = Plotter(
+    #     results=results, model_name=evaluator.model.name, beta=2
+    # )
 
     # plotter.plot_scores()
 

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,100 +1,173 @@
 import pytest
-from unittest.mock import MagicMock, patch
-from presidio_evaluator.evaluation.plotter import Plotter
-from presidio_evaluator.evaluation import EvaluationResult
 from pathlib import Path
 import pandas as pd
+from plotly.graph_objs import Figure
+from unittest.mock import MagicMock, patch
+
+from presidio_evaluator.evaluation import EvaluationResult, ModelError
+from presidio_evaluator.evaluation.plotter import Plotter
 
 @pytest.fixture
 def mock_evaluation_result():
-    return EvaluationResult(
-        entity_recall_dict={"PERSON": 0.8, "LOCATION": 0.7},
-        entity_precision_dict={"PERSON": 0.9, "LOCATION": 0.6},
-        n_dict={"PERSON": 50, "LOCATION": 30},
-        pii_recall=0.75,
-        pii_precision=0.85,
-        pii_f=0.8,
-        n=80,
-        model_errors=[]
-    )
+    result = MagicMock(spec=EvaluationResult)
+    result.entity_recall_dict = {"PERSON": 0.8, "LOCATION": 0.7}
+    result.entity_precision_dict = {"PERSON": 0.9, "LOCATION": 0.85}
+    result.n_dict = {"PERSON": 100, "LOCATION": 50}
+    result.pii_recall = 0.75
+    result.pii_precision = 0.88
+    result.pii_f = 0.8
+    result.n = 150
+    result.model_errors = []  # Empty list for test cases
+    return result
 
-@pytest.mark.parametrize("output_path", [None, Path("/tmp/plots")])
-def test_plot_scores(mock_evaluation_result, output_path):
-    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+@pytest.fixture
+def mock_figure():
+    fig = MagicMock(spec=Figure)
+    fig.show = MagicMock()
+    fig.write_image = MagicMock()
+    return fig
 
-    with patch("pathlib.Path.mkdir") as mock_mkdir, patch("plotly.graph_objs.Figure.write_image") as mock_write_image, patch("plotly.graph_objs.Figure.show") as mock_show:
-        plotter.plot_scores(output_path=output_path)
+class TestPlotter:
+    def test_save_fig_to_file_creates_directory(self, mock_evaluation_result, tmp_path):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result)
+        mock_fig = MagicMock(spec=Figure)
 
-        if output_path:
-            # If output_path is provided, ensure plots are saved to the correct paths
-            mock_mkdir.assert_called_once()
-            expected_recall_path = output_path / "TestModel-recall.png"
-            expected_precision_path = output_path / "TestModel-precision.png"
-            expected_fbeta_path = output_path / "TestModel-fbeta.png"
+        # Execute
+        plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
 
-            mock_write_image.assert_any_call(expected_recall_path)
-            mock_write_image.assert_any_call(expected_precision_path)
-            mock_write_image.assert_any_call(expected_fbeta_path)
-            assert mock_write_image.call_count == 3  # Three plots: recall, precision, F-beta
-        else:
-            # If output_path is not provided, ensure plots are shown instead of saved
-            mock_show.assert_called()
-            assert mock_show.call_count == 3  # Three plots: recall, precision, F-beta
+        # Assert
+        assert output_dir.exists()
+        mock_fig.write_image.assert_called_once_with(
+            Path(output_dir, f"{plotter.model_name}-test-figure.png")
+        )
 
+    def test_save_fig_to_file_different_formats(self, mock_evaluation_result, tmp_path):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result, save_as="svg")
+        mock_fig = MagicMock(spec=Figure)
 
-@pytest.mark.parametrize("output_path", [None, Path("/tmp/plots")])
-def test_plot_confusion_matrix(mock_evaluation_result, output_path):
-    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
-    entities = ["PERSON", "LOCATION"]
-    confmatrix = [[40, 10], [5, 25]]  # Example confusion matrix
+        # Execute
+        plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
 
-    with patch("pathlib.Path.mkdir") as mock_mkdir, patch("plotly.graph_objs.Figure.write_image") as mock_write_image, patch("plotly.graph_objs.Figure.show") as mock_show:
-        plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix, output_folder=output_path)
+        # Assert
+        mock_fig.write_image.assert_called_once_with(
+            Path(output_dir, f"{plotter.model_name}-test-figure.svg")
+        )
 
-        if output_path:
-            # If output_path is provided, ensure the confusion matrix is saved
-            mock_mkdir.assert_called_once()
-            expected_path = output_path / "TestModel-confusion-matrix.png"
-            mock_write_image.assert_called_once_with(expected_path)
-        else:
-            # If output_path is not provided, ensure the confusion matrix is shown
-            mock_show.assert_called_once()
+    @patch('plotly.express.bar', return_value=MagicMock(spec=Figure))
+    def test_plot_scores_saves_multiple_figures(self, mock_px_bar, mock_evaluation_result, tmp_path):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result)
+        mock_fig = mock_px_bar.return_value
 
+        # Execute
+        plotter.plot_scores(output_dir)
 
-@pytest.mark.parametrize("output_path", [None, Path("/tmp/plots")])
-def test_plot_most_common_tokens(mock_evaluation_result, output_path):
-    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+        # Assert - should create 3 figures (beta, recall, precision)
+        expected_paths = [
+            str(Path(output_dir, f"{plotter.model_name}-scores-f_beta.png")),
+            str(Path(output_dir, f"{plotter.model_name}-scores-recall.png")),
+            str(Path(output_dir, f"{plotter.model_name}-scores-precision.png"))
+        ]
+        assert mock_fig.write_image.call_count == 3
+        actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
+        assert actual_paths == expected_paths
 
-    with patch("pathlib.Path.mkdir") as mock_mkdir, patch("plotly.graph_objs.Figure.write_image") as mock_write_image, patch("plotly.graph_objs.Figure.show") as mock_show:
-        plotter.plot_most_common_tokens(output_folder=output_path)
+    @patch('presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe')
+    @patch('presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe')
+    @patch('plotly.express.histogram', return_value=MagicMock(spec=Figure))
+    def test_plot_most_common_tokens_saves_figures(
+        self, mock_px_histogram, mock_get_fns, mock_get_fps, 
+        mock_evaluation_result, tmp_path
+    ):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result)
+        
+        # Mock dataframes with some test data
+        test_data = {
+            'token': ['test1', 'test2'],
+            'prediction': ['PERSON', 'LOCATION'],
+            'annotation': ['PERSON', 'LOCATION']
+        }
+        mock_get_fps.return_value = pd.DataFrame(test_data)
+        mock_get_fns.return_value = pd.DataFrame(test_data)
+        mock_fig = mock_px_histogram.return_value
 
-        if output_path:
-            # If output_path is provided, ensure the plots are saved
-            mock_mkdir.assert_called_once()
-            expected_path = output_path / "TestModel-common-errors.png"
-            mock_write_image.assert_called()  # Called for both false positives and false negatives
-        else:
-            # If output_path is not provided, ensure the plots are shown
-            mock_show.assert_called()
+        # Execute
+        plotter.plot_most_common_tokens(output_dir)
 
-def test_save_fig_to_file(mock_evaluation_result):
-    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
-    mock_fig = MagicMock()
+        # Assert - should create 2 figures (false positives and false negatives)
+        expected_paths = [
+            str(Path(output_dir, f"{plotter.model_name}-common-errors-fn.png")),
+            str(Path(output_dir, f"{plotter.model_name}-common-errors-fp.png"))
+        ]
+        assert mock_fig.write_image.call_count == 2
+        actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
+        assert actual_paths == expected_paths
 
-    with patch("pathlib.Path.mkdir") as mock_mkdir:
-        plotter.save_fig_to_file(fig=mock_fig, output_folder=Path("/tmp"), file_name="test")
-        mock_fig.write_image.assert_called_once_with(Path("/tmp", "TestModel-test.png"))
-        mock_mkdir.assert_called_once()
+    @patch('plotly.express.imshow', return_value=MagicMock(spec=Figure))
+    def test_plot_confusion_matrix_saves_figure(self, mock_px_imshow, mock_evaluation_result, tmp_path):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result)
+        mock_fig = mock_px_imshow.return_value
+        entities = ["PERSON", "LOCATION"]
+        conf_matrix = [[10, 2], [1, 8]]
 
-def test_save_fig_to_correct_path(mock_evaluation_result):
-    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
-    mock_fig = MagicMock()
-    output_folder = Path("/tmp")
-    file_name = "test"
+        # Execute
+        plotter.plot_confusion_matrix(entities, conf_matrix, output_dir)
 
-    with patch("pathlib.Path.mkdir") as mock_mkdir:
-        with patch("pathlib.Path.exists", return_value=True):
-            plotter.save_fig_to_file(fig=mock_fig, output_folder=output_folder, file_name=file_name)
-            expected_path = output_folder / f"TestModel-{file_name}.png"
-            mock_fig.write_image.assert_called_once_with(expected_path)
-            mock_mkdir.assert_called_once()
+        # Assert
+        expected_path = str(Path(output_dir, f"{plotter.model_name}-confusion-matrix.png"))
+        mock_fig.write_image.assert_called_once_with(Path(output_dir, f"{plotter.model_name}-confusion-matrix.png"))
+        assert str(mock_fig.write_image.call_args[0][0]) == expected_path
+
+    def test_special_chars_in_model_name(self, mock_evaluation_result, tmp_path):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result, model_name="model/with/slashes")
+        mock_fig = MagicMock(spec=Figure)
+
+        # Execute
+        plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
+
+        # Assert - slashes should be replaced with hyphens
+        expected_path = str(Path(output_dir, "model-with-slashes-test-figure.png"))
+        mock_fig.write_image.assert_called_once_with(Path(output_dir, "model-with-slashes-test-figure.png"))
+        assert str(mock_fig.write_image.call_args[0][0]) == expected_path
+
+    def test_plot_scores_without_output_folder(self, mock_evaluation_result):
+        # Setup
+        plotter = Plotter(mock_evaluation_result)
+        with patch('plotly.express.bar', return_value=MagicMock(spec=Figure)) as mock_px_bar:
+            mock_fig = mock_px_bar.return_value
+
+            # Execute
+            plotter.plot_scores(None)
+
+            # Assert - figures should only be shown, not saved
+            mock_fig.write_image.assert_not_called()
+            assert mock_fig.show.call_count == 3
+
+    def test_plot_most_common_tokens_empty_data(self, mock_evaluation_result, tmp_path):
+        # Setup
+        output_dir = tmp_path / "test_output"
+        plotter = Plotter(mock_evaluation_result)
+        
+        with patch('presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe') as mock_get_fps:
+            with patch('presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe') as mock_get_fns:
+                # Mock empty dataframes
+                mock_get_fps.return_value = None
+                mock_get_fns.return_value = None
+
+                # Execute
+                plotter.plot_most_common_tokens(output_dir)
+
+                # Assert - no figures should be saved when there's no data
+                # The function should complete without errors
+                assert True

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from presidio_evaluator.evaluation import EvaluationResult, ModelError
 from presidio_evaluator.evaluation.plotter import Plotter
 
+
 @pytest.fixture
 def mock_evaluation_result():
     result = MagicMock(spec=EvaluationResult)
@@ -20,12 +21,14 @@ def mock_evaluation_result():
     result.model_errors = []  # Empty list for test cases
     return result
 
+
 @pytest.fixture
 def mock_figure():
     fig = MagicMock(spec=Figure)
     fig.show = MagicMock()
     fig.write_image = MagicMock()
     return fig
+
 
 class TestPlotter:
     def test_save_fig_to_file_creates_directory(self, mock_evaluation_result, tmp_path):
@@ -57,8 +60,10 @@ class TestPlotter:
             Path(output_dir, f"{plotter.model_name}-test-figure.svg")
         )
 
-    @patch('plotly.express.bar', return_value=MagicMock(spec=Figure))
-    def test_plot_scores_saves_multiple_figures(self, mock_px_bar, mock_evaluation_result, tmp_path):
+    @patch("plotly.express.bar", return_value=MagicMock(spec=Figure))
+    def test_plot_scores_saves_multiple_figures(
+        self, mock_px_bar, mock_evaluation_result, tmp_path
+    ):
         # Setup
         output_dir = tmp_path / "test_output"
         plotter = Plotter(mock_evaluation_result)
@@ -71,28 +76,32 @@ class TestPlotter:
         expected_paths = [
             str(Path(output_dir, f"{plotter.model_name}-scores-f_beta.png")),
             str(Path(output_dir, f"{plotter.model_name}-scores-recall.png")),
-            str(Path(output_dir, f"{plotter.model_name}-scores-precision.png"))
+            str(Path(output_dir, f"{plotter.model_name}-scores-precision.png")),
         ]
         assert mock_fig.write_image.call_count == 3
         actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
         assert actual_paths == expected_paths
 
-    @patch('presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe')
-    @patch('presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe')
-    @patch('plotly.express.histogram', return_value=MagicMock(spec=Figure))
+    @patch("presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe")
+    @patch("presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe")
+    @patch("plotly.express.histogram", return_value=MagicMock(spec=Figure))
     def test_plot_most_common_tokens_saves_figures(
-        self, mock_px_histogram, mock_get_fns, mock_get_fps, 
-        mock_evaluation_result, tmp_path
+        self,
+        mock_px_histogram,
+        mock_get_fns,
+        mock_get_fps,
+        mock_evaluation_result,
+        tmp_path,
     ):
         # Setup
         output_dir = tmp_path / "test_output"
         plotter = Plotter(mock_evaluation_result)
-        
+
         # Mock dataframes with some test data
         test_data = {
-            'token': ['test1', 'test2'],
-            'prediction': ['PERSON', 'LOCATION'],
-            'annotation': ['PERSON', 'LOCATION']
+            "token": ["test1", "test2"],
+            "prediction": ["PERSON", "LOCATION"],
+            "annotation": ["PERSON", "LOCATION"],
         }
         mock_get_fps.return_value = pd.DataFrame(test_data)
         mock_get_fns.return_value = pd.DataFrame(test_data)
@@ -104,14 +113,16 @@ class TestPlotter:
         # Assert - should create 2 figures (false positives and false negatives)
         expected_paths = [
             str(Path(output_dir, f"{plotter.model_name}-common-errors-fn.png")),
-            str(Path(output_dir, f"{plotter.model_name}-common-errors-fp.png"))
+            str(Path(output_dir, f"{plotter.model_name}-common-errors-fp.png")),
         ]
         assert mock_fig.write_image.call_count == 2
         actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
         assert actual_paths == expected_paths
 
-    @patch('plotly.express.imshow', return_value=MagicMock(spec=Figure))
-    def test_plot_confusion_matrix_saves_figure(self, mock_px_imshow, mock_evaluation_result, tmp_path):
+    @patch("plotly.express.imshow", return_value=MagicMock(spec=Figure))
+    def test_plot_confusion_matrix_saves_figure(
+        self, mock_px_imshow, mock_evaluation_result, tmp_path
+    ):
         # Setup
         output_dir = tmp_path / "test_output"
         plotter = Plotter(mock_evaluation_result)
@@ -123,8 +134,12 @@ class TestPlotter:
         plotter.plot_confusion_matrix(entities, conf_matrix, output_dir)
 
         # Assert
-        expected_path = str(Path(output_dir, f"{plotter.model_name}-confusion-matrix.png"))
-        mock_fig.write_image.assert_called_once_with(Path(output_dir, f"{plotter.model_name}-confusion-matrix.png"))
+        expected_path = str(
+            Path(output_dir, f"{plotter.model_name}-confusion-matrix.png")
+        )
+        mock_fig.write_image.assert_called_once_with(
+            Path(output_dir, f"{plotter.model_name}-confusion-matrix.png")
+        )
         assert str(mock_fig.write_image.call_args[0][0]) == expected_path
 
     def test_special_chars_in_model_name(self, mock_evaluation_result, tmp_path):
@@ -138,13 +153,17 @@ class TestPlotter:
 
         # Assert - slashes should be replaced with hyphens
         expected_path = str(Path(output_dir, "model-with-slashes-test-figure.png"))
-        mock_fig.write_image.assert_called_once_with(Path(output_dir, "model-with-slashes-test-figure.png"))
+        mock_fig.write_image.assert_called_once_with(
+            Path(output_dir, "model-with-slashes-test-figure.png")
+        )
         assert str(mock_fig.write_image.call_args[0][0]) == expected_path
 
     def test_plot_scores_without_output_folder(self, mock_evaluation_result):
         # Setup
         plotter = Plotter(mock_evaluation_result)
-        with patch('plotly.express.bar', return_value=MagicMock(spec=Figure)) as mock_px_bar:
+        with patch(
+            "plotly.express.bar", return_value=MagicMock(spec=Figure)
+        ) as mock_px_bar:
             mock_fig = mock_px_bar.return_value
 
             # Execute
@@ -158,9 +177,13 @@ class TestPlotter:
         # Setup
         output_dir = tmp_path / "test_output"
         plotter = Plotter(mock_evaluation_result)
-        
-        with patch('presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe') as mock_get_fps:
-            with patch('presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe') as mock_get_fns:
+
+        with patch(
+            "presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe"
+        ) as mock_get_fps:
+            with patch(
+                "presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe"
+            ) as mock_get_fns:
                 # Mock empty dataframes
                 mock_get_fps.return_value = None
                 mock_get_fns.return_value = None

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from presidio_evaluator.evaluation.plotter import Plotter
+from presidio_evaluator.evaluation import EvaluationResult
+from pathlib import Path
+import pandas as pd
+
+@pytest.fixture
+def mock_evaluation_result():
+    return EvaluationResult(
+        entity_recall_dict={"PERSON": 0.8, "LOCATION": 0.7},
+        entity_precision_dict={"PERSON": 0.9, "LOCATION": 0.6},
+        n_dict={"PERSON": 50, "LOCATION": 30},
+        pii_recall=0.75,
+        pii_precision=0.85,
+        pii_f=0.8,
+        n=80,
+        model_errors=[]
+    )
+
+@pytest.mark.parametrize("output_path", [None, Path("/tmp/plots")])
+def test_plot_scores(mock_evaluation_result, output_path):
+    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+
+    with patch("pathlib.Path.mkdir") as mock_mkdir, patch("plotly.graph_objs.Figure.write_image") as mock_write_image, patch("plotly.graph_objs.Figure.show") as mock_show:
+        plotter.plot_scores(output_path=output_path)
+
+        if output_path:
+            # If output_path is provided, ensure plots are saved to the correct paths
+            mock_mkdir.assert_called_once()
+            expected_recall_path = output_path / "TestModel-recall.png"
+            expected_precision_path = output_path / "TestModel-precision.png"
+            expected_fbeta_path = output_path / "TestModel-fbeta.png"
+
+            mock_write_image.assert_any_call(expected_recall_path)
+            mock_write_image.assert_any_call(expected_precision_path)
+            mock_write_image.assert_any_call(expected_fbeta_path)
+            assert mock_write_image.call_count == 3  # Three plots: recall, precision, F-beta
+        else:
+            # If output_path is not provided, ensure plots are shown instead of saved
+            mock_show.assert_called()
+            assert mock_show.call_count == 3  # Three plots: recall, precision, F-beta
+
+
+@pytest.mark.parametrize("output_path", [None, Path("/tmp/plots")])
+def test_plot_confusion_matrix(mock_evaluation_result, output_path):
+    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+    entities = ["PERSON", "LOCATION"]
+    confmatrix = [[40, 10], [5, 25]]  # Example confusion matrix
+
+    with patch("pathlib.Path.mkdir") as mock_mkdir, patch("plotly.graph_objs.Figure.write_image") as mock_write_image, patch("plotly.graph_objs.Figure.show") as mock_show:
+        plotter.plot_confusion_matrix(entities=entities, confmatrix=confmatrix, output_folder=output_path)
+
+        if output_path:
+            # If output_path is provided, ensure the confusion matrix is saved
+            mock_mkdir.assert_called_once()
+            expected_path = output_path / "TestModel-confusion-matrix.png"
+            mock_write_image.assert_called_once_with(expected_path)
+        else:
+            # If output_path is not provided, ensure the confusion matrix is shown
+            mock_show.assert_called_once()
+
+
+@pytest.mark.parametrize("output_path", [None, Path("/tmp/plots")])
+def test_plot_most_common_tokens(mock_evaluation_result, output_path):
+    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+
+    with patch("pathlib.Path.mkdir") as mock_mkdir, patch("plotly.graph_objs.Figure.write_image") as mock_write_image, patch("plotly.graph_objs.Figure.show") as mock_show:
+        plotter.plot_most_common_tokens(output_folder=output_path)
+
+        if output_path:
+            # If output_path is provided, ensure the plots are saved
+            mock_mkdir.assert_called_once()
+            expected_path = output_path / "TestModel-common-errors.png"
+            mock_write_image.assert_called()  # Called for both false positives and false negatives
+        else:
+            # If output_path is not provided, ensure the plots are shown
+            mock_show.assert_called()
+
+def test_save_fig_to_file(mock_evaluation_result):
+    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+    mock_fig = MagicMock()
+
+    with patch("pathlib.Path.mkdir") as mock_mkdir:
+        plotter.save_fig_to_file(fig=mock_fig, output_folder=Path("/tmp"), file_name="test")
+        mock_fig.write_image.assert_called_once_with(Path("/tmp", "TestModel-test.png"))
+        mock_mkdir.assert_called_once()
+
+def test_save_fig_to_correct_path(mock_evaluation_result):
+    plotter = Plotter(results=mock_evaluation_result, model_name="TestModel")
+    mock_fig = MagicMock()
+    output_folder = Path("/tmp")
+    file_name = "test"
+
+    with patch("pathlib.Path.mkdir") as mock_mkdir:
+        with patch("pathlib.Path.exists", return_value=True):
+            plotter.save_fig_to_file(fig=mock_fig, output_folder=output_folder, file_name=file_name)
+            expected_path = output_folder / f"TestModel-{file_name}.png"
+            mock_fig.write_image.assert_called_once_with(expected_path)
+            mock_mkdir.assert_called_once()

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -30,167 +30,165 @@ def mock_figure():
     return fig
 
 
-class TestPlotter:
-    def test_save_fig_to_file_creates_directory(self, mock_evaluation_result, tmp_path):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result)
-        mock_fig = MagicMock(spec=Figure)
+def test_save_fig_to_file_creates_directory(mock_evaluation_result, tmp_path):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result)
+    mock_fig = MagicMock(spec=Figure)
 
-        # Execute
-        plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
+    # Execute
+    plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
 
-        # Assert
-        assert output_dir.exists()
-        mock_fig.write_image.assert_called_once_with(
-            Path(output_dir, f"{plotter.model_name}-test-figure.png")
-        )
+    # Assert
+    assert output_dir.exists()
+    mock_fig.write_image.assert_called_once_with(
+        Path(output_dir, f"{plotter.model_name}-test-figure.png")
+    )
 
-    def test_save_fig_to_file_different_formats(self, mock_evaluation_result, tmp_path):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result, save_as="svg")
-        mock_fig = MagicMock(spec=Figure)
+def test_save_fig_to_file_different_formats(mock_evaluation_result, tmp_path):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result, save_as="svg")
+    mock_fig = MagicMock(spec=Figure)
 
-        # Execute
-        plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
+    # Execute
+    plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
 
-        # Assert
-        mock_fig.write_image.assert_called_once_with(
-            Path(output_dir, f"{plotter.model_name}-test-figure.svg")
-        )
+    # Assert
+    mock_fig.write_image.assert_called_once_with(
+        Path(output_dir, f"{plotter.model_name}-test-figure.svg")
+    )
 
-    @patch("plotly.express.bar", return_value=MagicMock(spec=Figure))
-    def test_plot_scores_saves_multiple_figures(
-        self, mock_px_bar, mock_evaluation_result, tmp_path
-    ):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result)
+@patch("plotly.express.bar", return_value=MagicMock(spec=Figure))
+def test_plot_scores_saves_multiple_figures(
+    mock_px_bar, mock_evaluation_result, tmp_path
+):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result)
+    mock_fig = mock_px_bar.return_value
+
+    # Execute
+    plotter.plot_scores(output_dir)
+
+    # Assert - should create 3 figures (beta, recall, precision)
+    expected_paths = [
+        str(Path(output_dir, f"{plotter.model_name}-scores-f_beta.png")),
+        str(Path(output_dir, f"{plotter.model_name}-scores-recall.png")),
+        str(Path(output_dir, f"{plotter.model_name}-scores-precision.png")),
+    ]
+    assert mock_fig.write_image.call_count == 3
+    actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
+    assert actual_paths == expected_paths
+
+@patch("presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe")
+@patch("presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe")
+@patch("plotly.express.histogram", return_value=MagicMock(spec=Figure))
+def test_plot_most_common_tokens_saves_figures(
+    mock_px_histogram,
+    mock_get_fns,
+    mock_get_fps,
+    mock_evaluation_result,
+    tmp_path,
+):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result)
+
+    # Mock dataframes with some test data
+    test_data = {
+        "token": ["test1", "test2"],
+        "prediction": ["PERSON", "LOCATION"],
+        "annotation": ["PERSON", "LOCATION"],
+    }
+    mock_get_fps.return_value = pd.DataFrame(test_data)
+    mock_get_fns.return_value = pd.DataFrame(test_data)
+    mock_fig = mock_px_histogram.return_value
+
+    # Execute
+    plotter.plot_most_common_tokens(output_dir)
+
+    # Assert - should create 2 figures (false positives and false negatives)
+    expected_paths = [
+        str(Path(output_dir, f"{plotter.model_name}-common-errors-fn.png")),
+        str(Path(output_dir, f"{plotter.model_name}-common-errors-fp.png")),
+    ]
+    assert mock_fig.write_image.call_count == 2
+    actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
+    assert actual_paths == expected_paths
+
+@patch("plotly.express.imshow", return_value=MagicMock(spec=Figure))
+def test_plot_confusion_matrix_saves_figure(
+    mock_px_imshow, mock_evaluation_result, tmp_path
+):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result)
+    mock_fig = mock_px_imshow.return_value
+    entities = ["PERSON", "LOCATION"]
+    conf_matrix = [[10, 2], [1, 8]]
+
+    # Execute
+    plotter.plot_confusion_matrix(entities, conf_matrix, output_dir)
+
+    # Assert
+    expected_path = str(
+        Path(output_dir, f"{plotter.model_name}-confusion-matrix.png")
+    )
+    mock_fig.write_image.assert_called_once_with(
+        Path(output_dir, f"{plotter.model_name}-confusion-matrix.png")
+    )
+    assert str(mock_fig.write_image.call_args[0][0]) == expected_path
+
+def test_special_chars_in_model_name(mock_evaluation_result, tmp_path):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result, model_name="model/with/slashes")
+    mock_fig = MagicMock(spec=Figure)
+
+    # Execute
+    plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
+
+    # Assert - slashes should be replaced with hyphens
+    expected_path = str(Path(output_dir, "model-with-slashes-test-figure.png"))
+    mock_fig.write_image.assert_called_once_with(
+        Path(output_dir, "model-with-slashes-test-figure.png")
+    )
+    assert str(mock_fig.write_image.call_args[0][0]) == expected_path
+
+def test_plot_scores_without_output_folder(mock_evaluation_result):
+    # Setup
+    plotter = Plotter(mock_evaluation_result)
+    with patch(
+        "plotly.express.bar", return_value=MagicMock(spec=Figure)
+    ) as mock_px_bar:
         mock_fig = mock_px_bar.return_value
 
         # Execute
-        plotter.plot_scores(output_dir)
+        plotter.plot_scores(None)
 
-        # Assert - should create 3 figures (beta, recall, precision)
-        expected_paths = [
-            str(Path(output_dir, f"{plotter.model_name}-scores-f_beta.png")),
-            str(Path(output_dir, f"{plotter.model_name}-scores-recall.png")),
-            str(Path(output_dir, f"{plotter.model_name}-scores-precision.png")),
-        ]
-        assert mock_fig.write_image.call_count == 3
-        actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
-        assert actual_paths == expected_paths
+        # Assert - figures should only be shown, not saved
+        mock_fig.write_image.assert_not_called()
+        assert mock_fig.show.call_count == 3
 
-    @patch("presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe")
-    @patch("presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe")
-    @patch("plotly.express.histogram", return_value=MagicMock(spec=Figure))
-    def test_plot_most_common_tokens_saves_figures(
-        self,
-        mock_px_histogram,
-        mock_get_fns,
-        mock_get_fps,
-        mock_evaluation_result,
-        tmp_path,
-    ):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result)
+def test_plot_most_common_tokens_empty_data(mock_evaluation_result, tmp_path):
+    # Setup
+    output_dir = tmp_path / "test_output"
+    plotter = Plotter(mock_evaluation_result)
 
-        # Mock dataframes with some test data
-        test_data = {
-            "token": ["test1", "test2"],
-            "prediction": ["PERSON", "LOCATION"],
-            "annotation": ["PERSON", "LOCATION"],
-        }
-        mock_get_fps.return_value = pd.DataFrame(test_data)
-        mock_get_fns.return_value = pd.DataFrame(test_data)
-        mock_fig = mock_px_histogram.return_value
-
-        # Execute
-        plotter.plot_most_common_tokens(output_dir)
-
-        # Assert - should create 2 figures (false positives and false negatives)
-        expected_paths = [
-            str(Path(output_dir, f"{plotter.model_name}-common-errors-fn.png")),
-            str(Path(output_dir, f"{plotter.model_name}-common-errors-fp.png")),
-        ]
-        assert mock_fig.write_image.call_count == 2
-        actual_paths = [str(call[0][0]) for call in mock_fig.write_image.call_args_list]
-        assert actual_paths == expected_paths
-
-    @patch("plotly.express.imshow", return_value=MagicMock(spec=Figure))
-    def test_plot_confusion_matrix_saves_figure(
-        self, mock_px_imshow, mock_evaluation_result, tmp_path
-    ):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result)
-        mock_fig = mock_px_imshow.return_value
-        entities = ["PERSON", "LOCATION"]
-        conf_matrix = [[10, 2], [1, 8]]
-
-        # Execute
-        plotter.plot_confusion_matrix(entities, conf_matrix, output_dir)
-
-        # Assert
-        expected_path = str(
-            Path(output_dir, f"{plotter.model_name}-confusion-matrix.png")
-        )
-        mock_fig.write_image.assert_called_once_with(
-            Path(output_dir, f"{plotter.model_name}-confusion-matrix.png")
-        )
-        assert str(mock_fig.write_image.call_args[0][0]) == expected_path
-
-    def test_special_chars_in_model_name(self, mock_evaluation_result, tmp_path):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result, model_name="model/with/slashes")
-        mock_fig = MagicMock(spec=Figure)
-
-        # Execute
-        plotter.save_fig_to_file(mock_fig, output_dir, "test-figure")
-
-        # Assert - slashes should be replaced with hyphens
-        expected_path = str(Path(output_dir, "model-with-slashes-test-figure.png"))
-        mock_fig.write_image.assert_called_once_with(
-            Path(output_dir, "model-with-slashes-test-figure.png")
-        )
-        assert str(mock_fig.write_image.call_args[0][0]) == expected_path
-
-    def test_plot_scores_without_output_folder(self, mock_evaluation_result):
-        # Setup
-        plotter = Plotter(mock_evaluation_result)
+    with patch(
+        "presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe"
+    ) as mock_get_fps:
         with patch(
-            "plotly.express.bar", return_value=MagicMock(spec=Figure)
-        ) as mock_px_bar:
-            mock_fig = mock_px_bar.return_value
+            "presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe"
+        ) as mock_get_fns:
+            # Mock empty dataframes
+            mock_get_fps.return_value = None
+            mock_get_fns.return_value = None
 
             # Execute
-            plotter.plot_scores(None)
+            plotter.plot_most_common_tokens(output_dir)
 
-            # Assert - figures should only be shown, not saved
-            mock_fig.write_image.assert_not_called()
-            assert mock_fig.show.call_count == 3
-
-    def test_plot_most_common_tokens_empty_data(self, mock_evaluation_result, tmp_path):
-        # Setup
-        output_dir = tmp_path / "test_output"
-        plotter = Plotter(mock_evaluation_result)
-
-        with patch(
-            "presidio_evaluator.evaluation.model_error.ModelError.get_fps_dataframe"
-        ) as mock_get_fps:
-            with patch(
-                "presidio_evaluator.evaluation.model_error.ModelError.get_fns_dataframe"
-            ) as mock_get_fns:
-                # Mock empty dataframes
-                mock_get_fps.return_value = None
-                mock_get_fns.return_value = None
-
-                # Execute
-                plotter.plot_most_common_tokens(output_dir)
-
-                # Assert - no figures should be saved when there's no data
-                # The function should complete without errors
-                assert True
+            # Assert - no figures should be saved when there's no data
+            # The function should complete without errors
+            assert True


### PR DESCRIPTION
This PR includes the fixes of issues 128 to 130. In issue 128, the output_path is now passed as an argument to the plot functions instead of to the Plotter instance. In issue 129, the plotter docstring was edited to describe the parameters in a clearer way. In issue 130, the experiment tracker path is now a parameter. 