### PR TITLE
Fix swapped annotation/prediction fields in _get_model_error

### DIFF
--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -1082,8 +1082,8 @@ class SpanEvaluator(BaseEvaluator):
 
         return ModelError(
             error_type=error_type,
-            annotation=prediction,
-            prediction=annotation,
+            annotation=annotation,
+            prediction=prediction,
             full_text=pred_span.entity_value
             if error_type == ErrorType.FP
             else ann_span.entity_value,


### PR DESCRIPTION
Hi, I noticed that `ModelError.get_fps_dataframe` and `ModelError.get_fns_dataframe` had their "annotated" and "prediction" columns incorrectly swapped, therefore the explanation would not match what was in these columns.

This is a simple bug fix that resolves the root of this issue.