### PR TITLE
Minor bug fixes in notebooks 5-6

### DIFF
--- a/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
+++ b/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b946feda",
    "metadata": {
     "ExecuteTime": {
@@ -132,8 +132,7 @@
    "source": [
     "# install presidio evaluator via pip if not yet installed\n",
     "\n",
-    "#!pip install presidio-evaluator\n",
-    "!pip install -e .."
+    "#!pip install presidio-evaluator\n"
    ]
   },
   {

--- a/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
+++ b/notebooks/4_Evaluate_Presidio_Analyzer.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 1,
    "id": "b946feda",
    "metadata": {
     "ExecuteTime": {
@@ -31,16 +31,114 @@
      "start_time": "2025-07-22T14:56:01.911124Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Obtaining file:///home/noaevag/presidio-research\n",
+      "  Installing build dependencies ... \u001b[?25ldone\n",
+      "\u001b[?25h  Checking if build backend supports build_editable ... \u001b[?25ldone\n",
+      "\u001b[?25h  Getting requirements to build editable ... \u001b[?25ldone\n",
+      "\u001b[?25h  Installing backend dependencies ... \u001b[?25ldone\n",
+      "\u001b[?25h  Preparing editable metadata (pyproject.toml) ... \u001b[?25ldone\n",
+      "\u001b[?25hRequirement already satisfied: faker>=40.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (40.11.1)\n",
+      "Requirement already satisfied: numpy>=2.4.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (2.4.3)\n",
+      "Requirement already satisfied: pandas>=3.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (3.0.1)\n",
+      "Requirement already satisfied: plotly>=6.6.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (6.6.0)\n",
+      "Requirement already satisfied: presidio-analyzer>=2.2.362 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (2.2.362)\n",
+      "Requirement already satisfied: presidio-anonymizer>=2.2.362 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (2.2.362)\n",
+      "Requirement already satisfied: python-dotenv>=1.2.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (1.2.2)\n",
+      "Requirement already satisfied: requests>=2.32.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (2.33.0)\n",
+      "Requirement already satisfied: scikit-learn>=1.8.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (1.8.0)\n",
+      "Requirement already satisfied: spacy>=3.8.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (3.8.13)\n",
+      "Requirement already satisfied: tqdm>=4.67.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (4.67.3)\n",
+      "Requirement already satisfied: transformers>=5.3.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (5.4.0)\n",
+      "Requirement already satisfied: xmltodict>=1.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio_evaluator==0.3) (1.0.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from pandas>=3.0.0->presidio_evaluator==0.3) (2.9.0.post0)\n",
+      "Requirement already satisfied: narwhals>=1.15.1 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from plotly>=6.6.0->presidio_evaluator==0.3) (2.18.0)\n",
+      "Requirement already satisfied: packaging in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from plotly>=6.6.0->presidio_evaluator==0.3) (26.0)\n",
+      "Requirement already satisfied: phonenumbers<10.0.0,>=8.12 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (9.0.26)\n",
+      "Requirement already satisfied: pydantic<3.0.0,>=2.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (2.12.5)\n",
+      "Requirement already satisfied: pyyaml in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (6.0.3)\n",
+      "Requirement already satisfied: regex in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (2026.3.32)\n",
+      "Requirement already satisfied: tldextract in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (5.3.1)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from pydantic<3.0.0,>=2.0.0->presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.41.5 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from pydantic<3.0.0,>=2.0.0->presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (2.41.5)\n",
+      "Requirement already satisfied: typing-extensions>=4.14.1 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from pydantic<3.0.0,>=2.0.0->presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (4.15.0)\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from pydantic<3.0.0,>=2.0.0->presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (0.4.2)\n",
+      "Requirement already satisfied: cryptography>=46.0.4 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from presidio-anonymizer>=2.2.362->presidio_evaluator==0.3) (46.0.6)\n",
+      "Requirement already satisfied: cffi>=2.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from cryptography>=46.0.4->presidio-anonymizer>=2.2.362->presidio_evaluator==0.3) (2.0.0)\n",
+      "Requirement already satisfied: pycparser in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from cffi>=2.0.0->cryptography>=46.0.4->presidio-anonymizer>=2.2.362->presidio_evaluator==0.3) (3.0)\n",
+      "Requirement already satisfied: six>=1.5 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from python-dateutil>=2.8.2->pandas>=3.0.0->presidio_evaluator==0.3) (1.17.0)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from requests>=2.32.0->presidio_evaluator==0.3) (3.4.6)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from requests>=2.32.0->presidio_evaluator==0.3) (3.11)\n",
+      "Requirement already satisfied: urllib3<3,>=1.26 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from requests>=2.32.0->presidio_evaluator==0.3) (2.6.3)\n",
+      "Requirement already satisfied: certifi>=2023.5.7 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from requests>=2.32.0->presidio_evaluator==0.3) (2026.2.25)\n",
+      "Requirement already satisfied: scipy>=1.10.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from scikit-learn>=1.8.0->presidio_evaluator==0.3) (1.17.1)\n",
+      "Requirement already satisfied: joblib>=1.3.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from scikit-learn>=1.8.0->presidio_evaluator==0.3) (1.5.3)\n",
+      "Requirement already satisfied: threadpoolctl>=3.2.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from scikit-learn>=1.8.0->presidio_evaluator==0.3) (3.6.0)\n",
+      "Requirement already satisfied: spacy-legacy<3.1.0,>=3.0.11 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (3.0.12)\n",
+      "Requirement already satisfied: spacy-loggers<2.0.0,>=1.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (1.0.5)\n",
+      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (1.0.15)\n",
+      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (2.0.13)\n",
+      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (3.0.13)\n",
+      "Requirement already satisfied: thinc<8.4.0,>=8.3.12 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (8.3.13)\n",
+      "Requirement already satisfied: wasabi<1.2.0,>=0.9.1 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (1.1.3)\n",
+      "Requirement already satisfied: srsly<3.0.0,>=2.5.3 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (2.5.3)\n",
+      "Requirement already satisfied: catalogue<2.1.0,>=2.0.6 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (2.0.10)\n",
+      "Requirement already satisfied: weasel<2.0.0,>=1.0.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (1.0.0)\n",
+      "Requirement already satisfied: confection<2.0.0,>=1.3.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (1.3.3)\n",
+      "Requirement already satisfied: typer<1.0.0,>=0.3.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (0.24.1)\n",
+      "Requirement already satisfied: jinja2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (3.1.6)\n",
+      "Requirement already satisfied: setuptools in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from spacy>=3.8.0->presidio_evaluator==0.3) (82.0.1)\n",
+      "Requirement already satisfied: blis<1.4.0,>=1.3.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from thinc<8.4.0,>=8.3.12->spacy>=3.8.0->presidio_evaluator==0.3) (1.3.3)\n",
+      "Requirement already satisfied: click>=8.2.1 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (8.3.1)\n",
+      "Requirement already satisfied: shellingham>=1.3.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (1.5.4)\n",
+      "Requirement already satisfied: rich>=12.3.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (14.3.3)\n",
+      "Requirement already satisfied: annotated-doc>=0.0.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (0.0.4)\n",
+      "Requirement already satisfied: cloudpathlib>=0.7.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (0.23.0)\n",
+      "Requirement already satisfied: smart-open>=5.2.1 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (7.5.1)\n",
+      "Requirement already satisfied: httpx>=0.24.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (0.28.1)\n",
+      "Requirement already satisfied: anyio in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from httpx>=0.24.0->weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (4.13.0)\n",
+      "Requirement already satisfied: httpcore==1.* in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from httpx>=0.24.0->weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (1.0.9)\n",
+      "Requirement already satisfied: h11>=0.16 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.24.0->weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (0.16.0)\n",
+      "Requirement already satisfied: markdown-it-py>=2.2.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from rich>=12.3.0->typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (4.0.0)\n",
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from rich>=12.3.0->typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (2.19.2)\n",
+      "Requirement already satisfied: mdurl~=0.1 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer<1.0.0,>=0.3.0->spacy>=3.8.0->presidio_evaluator==0.3) (0.1.2)\n",
+      "Requirement already satisfied: wrapt in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from smart-open>=5.2.1->weasel<2.0.0,>=1.0.0->spacy>=3.8.0->presidio_evaluator==0.3) (2.1.2)\n",
+      "Requirement already satisfied: huggingface-hub<2.0,>=1.5.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from transformers>=5.3.0->presidio_evaluator==0.3) (1.8.0)\n",
+      "Requirement already satisfied: tokenizers<=0.23.0,>=0.22.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from transformers>=5.3.0->presidio_evaluator==0.3) (0.22.1)\n",
+      "Requirement already satisfied: safetensors>=0.4.3 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from transformers>=5.3.0->presidio_evaluator==0.3) (0.6.2)\n",
+      "Requirement already satisfied: filelock>=3.10.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from huggingface-hub<2.0,>=1.5.0->transformers>=5.3.0->presidio_evaluator==0.3) (3.25.2)\n",
+      "Requirement already satisfied: fsspec>=2023.5.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from huggingface-hub<2.0,>=1.5.0->transformers>=5.3.0->presidio_evaluator==0.3) (2025.10.0)\n",
+      "Requirement already satisfied: hf-xet<2.0.0,>=1.4.2 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from huggingface-hub<2.0,>=1.5.0->transformers>=5.3.0->presidio_evaluator==0.3) (1.4.2)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from jinja2->spacy>=3.8.0->presidio_evaluator==0.3) (3.0.3)\n",
+      "Requirement already satisfied: requests-file>=1.4 in /home/noaevag/miniconda3/envs/presidio/lib/python3.12/site-packages (from tldextract->presidio-analyzer>=2.2.362->presidio_evaluator==0.3) (3.0.1)\n",
+      "Building wheels for collected packages: presidio_evaluator\n",
+      "  Building editable for presidio_evaluator (pyproject.toml) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for presidio_evaluator: filename=presidio_evaluator-0.3-py3-none-any.whl size=12409 sha256=1cfb51067e8de9f9c11f420120fd4bc94adf5f2b2fa0fc4f12056a0daa4741b7\n",
+      "  Stored in directory: /tmp/pip-ephem-wheel-cache-fy0c62h2/wheels/7e/f0/a4/6adf642173042e249a26e8496268f8cc5a0a6275c632844502\n",
+      "Successfully built presidio_evaluator\n",
+      "Installing collected packages: presidio_evaluator\n",
+      "  Attempting uninstall: presidio_evaluator\n",
+      "    Found existing installation: presidio_evaluator 0.3\n",
+      "    Uninstalling presidio_evaluator-0.3:\n",
+      "      Successfully uninstalled presidio_evaluator-0.3\n",
+      "Successfully installed presidio_evaluator-0.3\n"
+     ]
+    }
+   ],
    "source": [
     "# install presidio evaluator via pip if not yet installed\n",
     "\n",
-    "#!pip install presidio-evaluator"
+    "#!pip install presidio-evaluator\n",
+    "!pip install -e .."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ae85cae9",
    "metadata": {
     "ExecuteTime": {
@@ -82,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "f4cbd55c",
    "metadata": {
     "ExecuteTime": {
@@ -95,7 +193,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "tokenizing input: 100%|██████████| 1500/1500 [00:07<00:00, 213.89it/s]"
+      "tokenizing input:   0%|          | 0/1500 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loading model en_core_web_sm\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tokenizing input: 100%|██████████| 1500/1500 [00:10<00:00, 137.09it/s]"
      ]
     },
     {
@@ -129,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "c164ea07",
    "metadata": {
     "ExecuteTime": {
@@ -158,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "77aedae6",
    "metadata": {
     "ExecuteTime": {
@@ -217,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "d6b6b4f3895023d1",
    "metadata": {
     "ExecuteTime": {
@@ -225,154 +337,7 @@
      "start_time": "2025-07-22T14:56:18.260381Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "A few examples sentences containing each entity:\n",
-      "\n",
-      "Entity: <ORGANIZATION> two example sentences:\n",
-      "\n",
-      "1) The address of Persint is 6750 Koskikatu 25 Apt. 864\n",
-      "Artilleros\n",
-      ", CO\n",
-      " Uruguay 64677\n",
-      "2) The Exversion Orchestra was founded in 1977. Since then, it has grown from a volunteer community orchestra to a fully professional orchestra serving Southern Tunisia\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <STREET_ADDRESS> two example sentences:\n",
-      "\n",
-      "1) The address of Persint is 6750 Koskikatu 25 Apt. 864\n",
-      "Artilleros\n",
-      ", CO\n",
-      " Uruguay 64677\n",
-      "2) Billing address: Sara Schwarz\n",
-      "    28245 Puruntie 82 Apt. 595\n",
-      "   LAPPEENRANTA\n",
-      "    SK\n",
-      "    53650\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <PERSON> two example sentences:\n",
-      "\n",
-      "1) Krisztián Szöllösy listed his top 20 songs for Entertainment Weekly and had the balls to list this song at #15. (What did he put at #1 you ask? Answer:\"Tube Snake Boogie\" by Szabina J Gelencsér ג€“ go figure)\n",
-      "2) My name is Rubija\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <DATE_TIME> two example sentences:\n",
-      "\n",
-      "1) The Exversion Orchestra was founded in 1977. Since then, it has grown from a volunteer community orchestra to a fully professional orchestra serving Southern Tunisia\n",
-      "2) When: 2000-04-16 11:34:35\n",
-      "Where: UPTON SCUDAMORE Country Club.\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <GPE> two example sentences:\n",
-      "\n",
-      "1) The Exversion Orchestra was founded in 1977. Since then, it has grown from a volunteer community orchestra to a fully professional orchestra serving Southern Tunisia\n",
-      "2) I will be travelling to Canada next week, so I need my passport to be ready by then\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <CREDIT_CARD> two example sentences:\n",
-      "\n",
-      "1) What is the limit for card 4454794511390933?\n",
-      "2) My card 4131034282458809939 is expiring this month. Please let me know process to it's extend validity.\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <US_SSN> two example sentences:\n",
-      "\n",
-      "1) Here's my SSN: 460-89-9847\n",
-      "2) Here's my SSN: 514-69-0360\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <US_DRIVER_LICENSE> two example sentences:\n",
-      "\n",
-      "1) my driver's license number is 2270-66-1551\n",
-      "2) My driver's license number is 6940579\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <AGE> two example sentences:\n",
-      "\n",
-      "1) This 79 year old female complaining of stomach pain.\n",
-      "2) This 74 year old female complaining of stomach pain.\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <ZIP_CODE> two example sentences:\n",
-      "\n",
-      "1) Billing address: Sara Schwarz\n",
-      "    28245 Puruntie 82 Apt. 595\n",
-      "   LAPPEENRANTA\n",
-      "    SK\n",
-      "    53650\n",
-      "2) ZIP: 3520\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <TITLE> two example sentences:\n",
-      "\n",
-      "1) My name appears incorrectly on credit card statement could you please correct it to Dr. Cettina Fanucci?\n",
-      "2) My name appears incorrectly on credit card statement could you please correct it to Dr. Berta Szöllössy?\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <DOMAIN_NAME> two example sentences:\n",
-      "\n",
-      "1) My website is http://www.ScrapbookInsider.com.pt/\n",
-      "2) I've shared files with you https://ClickPhobia.com.br/\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <EMAIL_ADDRESS> two example sentences:\n",
-      "\n",
-      "1) Could you please send me the last billed amount for cc 4007070753690781 on my e-mail UtaKortig@jourrapide.com?\n",
-      "2) You said your email is UshurmaDratchev@rhyta.com. Is that correct?\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <PHONE_NUMBER> two example sentences:\n",
-      "\n",
-      "1) I have done an online order but didn't get any message on my registered 905-674-3793. Could you please look into it ?\n",
-      "2) Janka M. Szász\n",
-      "\n",
-      "Network and computer systems administrator\n",
-      "\n",
-      "Personal Info:\n",
-      "Phone:\n",
-      "60-56-85-91\n",
-      "\n",
-      "E-mail:\n",
-      "SzaszJanka@cuvox.de\n",
-      "\n",
-      "Website:\n",
-      "https://www.UEarly.se/\n",
-      "\n",
-      "Address:\n",
-      "Brucker Bundesstrasse 31 Zezig Streets\n",
-      " Suite 245\n",
-      " FÜRLING\n",
-      " Austria 25173.\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <IBAN_CODE> two example sentences:\n",
-      "\n",
-      "1) Are there any charges applied for money transfer from GB56HXDO88167774656119 to other bank accounts\n",
-      "2) My IBAN is GB59IFUE40226315499137\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <IP_ADDRESS> two example sentences:\n",
-      "\n",
-      "1) Inject SELECT * FROM Users WHERE client_ip = ?%//!%20\\|106.31.73.20|%20/\n",
-      "2) Inject SELECT * FROM Users WHERE client_ip = ?%//!%20\\|86.121.97.248|%20/\n",
-      "------------------------------------\n",
-      "\n",
-      "Entity: <NRP> two example sentences:\n",
-      "\n",
-      "1) From the film English graffiti (also features Kate M Begum. What's not to love?\n",
-      "2) The restaurant is located at 704 1436 Redbud Drive\n",
-      "Cite Essanaouber\n",
-      ", 32\n",
-      " 60810. It serves great Slovenian food.\n",
-      "------------------------------------\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"A few examples sentences containing each entity:\\n\")\n",
     "for entity in entity_counts.keys():\n",
@@ -400,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "313b508f-e901-40b9-b575-c7fb8a794652",
    "metadata": {
     "ExecuteTime": {
@@ -410,14 +375,32 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:presidio-analyzer:Failed to enable GPU (cuda), falling back to CPU: Cannot use GPU, CuPy is not installed\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: pl, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - EsNifRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - EsNieRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItDriverLicenseRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItFiscalCodeRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItVatCodeRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItIdentityCardRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItPassportRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - PlPeselRecognizer supported languages: pl, registry supported languages: en\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "'Supported entities for English:'\n",
-      "['US_SSN', 'PERSON', 'NRP', 'MEDICAL_LICENSE', 'EMAIL_ADDRESS', 'CREDIT_CARD',\n",
-      " 'CRYPTO', 'US_DRIVER_LICENSE', 'UK_NHS', 'IBAN_CODE', 'PHONE_NUMBER', 'URL',\n",
-      " 'MAC_ADDRESS', 'LOCATION', 'US_PASSPORT', 'IP_ADDRESS', 'US_BANK_NUMBER',\n",
-      " 'DATE_TIME', 'US_ITIN']\n",
+      "['MEDICAL_LICENSE', 'US_PASSPORT', 'PHONE_NUMBER', 'MAC_ADDRESS', 'CREDIT_CARD',\n",
+      " 'US_SSN', 'US_BANK_NUMBER', 'US_DRIVER_LICENSE', 'NRP', 'US_ITIN', 'URL',\n",
+      " 'PERSON', 'EMAIL_ADDRESS', 'IBAN_CODE', 'IP_ADDRESS', 'UK_NHS', 'CRYPTO',\n",
+      " 'DATE_TIME', 'LOCATION']\n",
       "\n",
       "Loaded recognizers for English:\n",
       "['CreditCardRecognizer', 'UsBankRecognizer', 'UsLicenseRecognizer',\n",
@@ -453,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "29d39ff1-4f14-4e32-ae84-ecc6c739f829",
    "metadata": {
     "ExecuteTime": {
@@ -462,7 +445,17 @@
     },
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------\n",
+      "Entities supported by this Presidio Analyzer instance:\n",
+      "MEDICAL_LICENSE, US_PASSPORT, PHONE_NUMBER, MAC_ADDRESS, CREDIT_CARD, US_SSN, US_BANK_NUMBER, US_DRIVER_LICENSE, NRP, US_ITIN, URL, PERSON, EMAIL_ADDRESS, IBAN_CODE, IP_ADDRESS, UK_NHS, CRYPTO, DATE_TIME, LOCATION\n"
+     ]
+    }
+   ],
    "source": [
     "# Wrap the analyzer\n",
     "wrapped_analyzer = PresidioAnalyzerWrapper(analyzer_engine=analyzer_engine)\n",
@@ -487,10 +480,105 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "be816350",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 14.3 s, sys: 135 ms, total: 14.4 s\n",
+      "Wall time: 14.1 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sentence_id</th>\n",
+       "      <th>token</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>prediction</th>\n",
+       "      <th>start_indices</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>The</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>address</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>of</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>Persint</td>\n",
+       "      <td>ORGANIZATION</td>\n",
+       "      <td>O</td>\n",
+       "      <td>15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>is</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sentence_id    token    annotation prediction  start_indices\n",
+       "0            0      The             O          O              0\n",
+       "1            0  address             O          O              4\n",
+       "2            0       of             O          O             12\n",
+       "3            0  Persint  ORGANIZATION          O             15\n",
+       "4            0       is             O          O             23"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%time\n",
     "results_df = wrapped_analyzer.predict_dataset(dataset)\n",
@@ -511,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "ff2e676f44f72e4e",
    "metadata": {
     "ExecuteTime": {
@@ -527,10 +615,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "465c5e54",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_380926/2848899579.py:2: UserWarning: Some annotations and predictions resolve to different canonical entities: 'AGE' vs 'DATE_TIME', 'CREDIT_CARD' vs 'DATE_TIME', 'CREDIT_CARD' vs 'PHONE_NUMBER', 'DOMAIN_NAME' vs 'URL', 'GPE' vs 'DATE_TIME', 'GPE' vs 'LOCATION', 'GPE' vs 'NRP', 'GPE' vs 'PERSON', 'IP_ADDRESS' vs 'PERSON', 'NRP' vs 'LOCATION', 'NRP' vs 'PERSON', 'ORGANIZATION' vs 'LOCATION', 'ORGANIZATION' vs 'NRP', 'ORGANIZATION' vs 'PERSON', 'PERSON' vs 'LOCATION', 'PERSON' vs 'NRP', 'PHONE_NUMBER' vs 'DATE_TIME', 'STREET_ADDRESS' vs 'DATE_TIME', 'STREET_ADDRESS' vs 'LOCATION', 'STREET_ADDRESS' vs 'NRP', 'STREET_ADDRESS' vs 'PERSON', 'STREET_ADDRESS' vs 'PHONE_NUMBER', 'TITLE' vs 'PERSON', 'US_DRIVER_LICENSE' vs 'PHONE_NUMBER', 'ZIP_CODE' vs 'DATE_TIME', 'ZIP_CODE' vs 'PERSON'. This will count as false negatives/positives. To fix this: (a) call get_mapped_results_dataframe(results_df, hierarchy=2) to use a broader mapping level where both resolve to the same entity, or (b) call mapper.map({'<label>': '<canonical>'}) to manually specify the mapping.\n",
+      "  mapped_df = mapper.get_mapped_results_dataframe(results_df)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">19 exact</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>TITLE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">LOCATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>LOCATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">URL</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>URL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sentence_id</th>\n",
+       "      <th>token</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>prediction</th>\n",
+       "      <th>start_indices</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>The</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>address</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>of</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>Persint</td>\n",
+       "      <td>ORGANIZATION</td>\n",
+       "      <td>O</td>\n",
+       "      <td>15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>is</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sentence_id    token    annotation prediction  start_indices\n",
+       "0            0      The             O          O              0\n",
+       "1            0  address             O          O              4\n",
+       "2            0       of             O          O             12\n",
+       "3            0  Persint  ORGANIZATION          O             15\n",
+       "4            0       is             O          O             23"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Auto-resolve labels from annotation + prediction columns and inspect the result\n",
     "mapped_df = mapper.get_mapped_results_dataframe(results_df)\n",
@@ -552,10 +747,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "88c6c806",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_380926/4259044786.py:8: UserWarning: Some annotations and predictions resolve to different canonical entities: 'CREDIT_CARD' vs 'DATE_TIME', 'CREDIT_CARD' vs 'PHONE_NUMBER', 'DOMAIN_NAME' vs 'URL', 'GPE' vs 'DATE_TIME', 'GPE' vs 'LOCATION', 'GPE' vs 'NRP', 'GPE' vs 'PERSON', 'IP_ADDRESS' vs 'PERSON', 'NRP' vs 'LOCATION', 'NRP' vs 'PERSON', 'ORGANIZATION' vs 'LOCATION', 'ORGANIZATION' vs 'NRP', 'ORGANIZATION' vs 'PERSON', 'PERSON' vs 'LOCATION', 'PERSON' vs 'NRP', 'PHONE_NUMBER' vs 'DATE_TIME', 'STREET_ADDRESS' vs 'DATE_TIME', 'STREET_ADDRESS' vs 'LOCATION', 'STREET_ADDRESS' vs 'NRP', 'STREET_ADDRESS' vs 'PERSON', 'STREET_ADDRESS' vs 'PHONE_NUMBER', 'US_DRIVER_LICENSE' vs 'PHONE_NUMBER', 'ZIP_CODE' vs 'DATE_TIME', 'ZIP_CODE' vs 'PERSON'. This will count as false negatives/positives. To fix this: (a) call get_mapped_results_dataframe(results_df, hierarchy=2) to use a broader mapping level where both resolve to the same entity, or (b) call mapper.map({'<label>': '<canonical>'}) to manually specify the mapping.\n",
+      "  mapped_df = mapper.get_mapped_results_dataframe(results_df)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">16 exact</span><span style=\"background:#0969da;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">2 manual</span><span style=\"background:#57606a;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">1 none</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#ddf4ff\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#0969da;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">MANUAL</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#ddf4ff\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#0969da;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">MANUAL</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">LOCATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>LOCATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">URL</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>URL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#f6f8fa\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#57606a;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">NONE</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><em style=\"color:#57606a\">None</em></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sentence_id</th>\n",
+       "      <th>token</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>prediction</th>\n",
+       "      <th>start_indices</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>The</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>address</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>of</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>Persint</td>\n",
+       "      <td>ORGANIZATION</td>\n",
+       "      <td>O</td>\n",
+       "      <td>15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>is</td>\n",
+       "      <td>O</td>\n",
+       "      <td>O</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sentence_id    token    annotation prediction  start_indices\n",
+       "0            0      The             O          O              0\n",
+       "1            0  address             O          O              4\n",
+       "2            0       of             O          O             12\n",
+       "3            0  Persint  ORGANIZATION          O             15\n",
+       "4            0       is             O          O             23"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Edit overrides below if anything needs correcting, then re-run this cell and the mapping cell above\n",
     "mapper.map({\n",
@@ -571,7 +873,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e8347063",
    "metadata": {},
    "outputs": [],
@@ -589,7 +891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "e114b2db",
    "metadata": {},
    "outputs": [
@@ -597,10 +899,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/omrimendels/Documents/github/presidio-research/presidio_evaluator/evaluation/span_evaluator.py:45: UserWarning:\n",
-      "\n",
-      "skip words not provided, using default skip words. If you want the evaluation to not use skip words, pass skip_words=[]\n",
-      "\n"
+      "WARNING:presidio_evaluator.evaluation.base_evaluator:skip words not provided, using default skip words. If you want the evaluation to not use skip words, pass skip_words=[]\n"
      ]
     }
    ],
@@ -610,7 +909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 13,
    "id": "83b5a724",
    "metadata": {},
    "outputs": [
@@ -618,7 +917,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "saving experiment data to /Users/omrimendels/Documents/github/presidio-research/notebooks/experiment_20260325-233729.json\n"
+      "saving experiment data to /home/noaevag/presidio-research/notebooks/experiment_20260329-232605.json\n"
      ]
     }
    ],
@@ -645,7 +944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "5b4d662d-596c-4a69-b3c9-1edcda20cc5b",
    "metadata": {
     "ExecuteTime": {
@@ -668,8 +967,8 @@
          "legendgroup": "",
          "marker": {
           "color": {
-           "bdata": "AAAAAABogkAAAAAAAIBLQAAAAAAAIGhAAAAAAABQhEAAAAAAAABhQAAAAAAAADBAAAAAAAAAFEAAAAAAAABQQAAAAAAAgEJAAAAAAACASEAAAAAAAAA1QAAAAAAAACxAAAAAAAAA+H8=",
-           "dtype": "f8"
+           "bdata": "4gC/ATcAwQCrAkoBAACdABAABQBAACUAAAAxAA4A5Ag=",
+           "dtype": "i2"
           },
           "coloraxis": "coloraxis",
           "pattern": {
@@ -688,22 +987,25 @@
          "texttemplate": "%{x:.2}",
          "type": "bar",
          "x": {
-          "bdata": "Rx8Lz+a0zT+gG/P00WriP5DgPoL7COY/Xx8zjL7E5D/4unZ7z+LpPwAAAAAAAPA/q6qqqqqq6j9eHlsRNJzUPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwP+NnlPgZJe4/avATvXOz5T8=",
+          "bdata": "AAAAAAAA+H8AAAAAAAD4f6Ab8/TRauI/5DiO4zjO5T8jS+L5umLjPwAAAAAAAPh/AAAAAAAA+H9RkfpHxrzqPwAAAAAAAPA/q6qqqqqq6j9eHlsRNJzUPwAAAAAAAPh/AAAAAAAA+H8AAAAAAADwP+NnlPgZJe4/u25lJswp5T8=",
           "dtype": "f8"
          },
          "xaxis": "x",
          "y": [
-          "LOCATION",
-          "NRP",
+          "ORGANIZATION",
+          "ADDRESS",
+          "NATIONALITY",
           "DATE_TIME",
           "PERSON",
-          "CREDIT_CARD",
-          "US_SSN",
-          "US_DRIVER_LICENSE",
+          "GPE",
+          "LOCATION",
+          "FINANCIAL",
+          "SSN",
+          "DRIVER_LICENSE",
           "PHONE_NUMBER",
+          "DOMAIN",
           "URL",
           "EMAIL_ADDRESS",
-          "IBAN_CODE",
           "IP_ADDRESS",
           "PII"
          ],
@@ -1604,8 +1906,8 @@
          "legendgroup": "",
          "marker": {
           "color": {
-           "bdata": "AAAAAABogkAAAAAAAIBLQAAAAAAAIGhAAAAAAABQhEAAAAAAAABhQAAAAAAAADBAAAAAAAAAFEAAAAAAAABQQAAAAAAAgEJAAAAAAACASEAAAAAAAAA1QAAAAAAAACxAAAAAAAAA+H8=",
-           "dtype": "f8"
+           "bdata": "4gC/ATcAwQCrAkoBAACdABAABQBAACUAAAAxAA4A5Ag=",
+           "dtype": "i2"
           },
           "coloraxis": "coloraxis",
           "pattern": {
@@ -1624,22 +1926,25 @@
          "texttemplate": "%{x:.2}",
          "type": "bar",
          "x": {
-          "bdata": "zFcO2ygqyz+eEuQpQZ7iP4Zbe2P1B+o/H4XrUbge5T+1tLS0tLToPwAAAAAAAPA/mpmZmZmZ6T8AAAAAAADTPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwP27btm3btu0/JbF+AWw75T8=",
+          "bdata": "AAAAAAAAAAAAAAAAAAAAAJ4S5ClBnuI/hlt7Y/UH6j8/BdZPgfXjPwAAAAAAAAAAAAAAAAAA+H/WYZSpeK7pPwAAAAAAAPA/mpmZmZmZ6T8AAAAAAADTPwAAAAAAAAAAAAAAAAAA+H8AAAAAAADwP27btm3btu0/WnI/HjWo5D8=",
           "dtype": "f8"
          },
          "xaxis": "x",
          "y": [
-          "LOCATION",
-          "NRP",
+          "ORGANIZATION",
+          "ADDRESS",
+          "NATIONALITY",
           "DATE_TIME",
           "PERSON",
-          "CREDIT_CARD",
-          "US_SSN",
-          "US_DRIVER_LICENSE",
+          "GPE",
+          "LOCATION",
+          "FINANCIAL",
+          "SSN",
+          "DRIVER_LICENSE",
           "PHONE_NUMBER",
+          "DOMAIN",
           "URL",
           "EMAIL_ADDRESS",
-          "IBAN_CODE",
           "IP_ADDRESS",
           "PII"
          ],
@@ -2540,8 +2845,8 @@
          "legendgroup": "",
          "marker": {
           "color": {
-           "bdata": "AAAAAABogkAAAAAAAIBLQAAAAAAAIGhAAAAAAABQhEAAAAAAAABhQAAAAAAAADBAAAAAAAAAFEAAAAAAAABQQAAAAAAAgEJAAAAAAACASEAAAAAAAAA1QAAAAAAAACxAAAAAAAAA+H8=",
-           "dtype": "f8"
+           "bdata": "4gC/ATcAwQCrAkoBAACdABAABQBAACUAAAAxAA4A5Ag=",
+           "dtype": "i2"
           },
           "coloraxis": "coloraxis",
           "pattern": {
@@ -2560,22 +2865,25 @@
          "texttemplate": "%{x:.2}",
          "type": "bar",
          "x": {
-          "bdata": "7zXpvSa91z+WexphuafhP/WmN73pTds/AT1YTet44z8AAAAAAADwPwAAAAAAAPA/AAAAAAAA8D/f8i3f8i3fPwAAAAAAAPA/AAAAAAAA8D8AAAAAAADwPwAAAAAAAPA/AtTCxbjN5z8=",
+          "bdata": "AAAAAAAA+H8AAAAAAAD4f5Z7GmG5p+E/E6d+zy1x2j9ZHxrrQ2PhPwAAAAAAAPh/AAAAAAAAAAAAAAAAAADwPwAAAAAAAPA/AAAAAAAA8D/f8i3f8i3fPwAAAAAAAPh/AAAAAAAAAAAAAAAAAADwPwAAAAAAAPA/wIcUpZJ25z8=",
           "dtype": "f8"
          },
          "xaxis": "x",
          "y": [
-          "LOCATION",
-          "NRP",
+          "ORGANIZATION",
+          "ADDRESS",
+          "NATIONALITY",
           "DATE_TIME",
           "PERSON",
-          "CREDIT_CARD",
-          "US_SSN",
-          "US_DRIVER_LICENSE",
+          "GPE",
+          "LOCATION",
+          "FINANCIAL",
+          "SSN",
+          "DRIVER_LICENSE",
           "PHONE_NUMBER",
+          "DOMAIN",
           "URL",
           "EMAIL_ADDRESS",
-          "IBAN_CODE",
           "IP_ADDRESS",
           "PII"
          ],
@@ -3474,7 +3782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 15,
    "id": "84c79050-c4aa-487d-b4e3-ade06f0a6340",
    "metadata": {
     "ExecuteTime": {
@@ -3518,7 +3826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "cfe3b38d440148cf",
    "metadata": {
     "ExecuteTime": {
@@ -3544,43 +3852,49 @@
          "texttemplate": "%{z}",
          "type": "heatmap",
          "x": [
-          "CREDIT_CARD",
+          "ADDRESS",
           "DATE_TIME",
+          "DOMAIN",
+          "DRIVER_LICENSE",
           "EMAIL_ADDRESS",
-          "IBAN_CODE",
+          "FINANCIAL",
+          "GPE",
           "IP_ADDRESS",
           "LOCATION",
-          "NRP",
+          "NATIONALITY",
+          "ORGANIZATION",
           "PERSON",
           "PHONE_NUMBER",
+          "SSN",
           "URL",
-          "US_DRIVER_LICENSE",
-          "US_SSN",
           "O",
           "Total"
          ],
          "xaxis": "x",
          "y": [
-          "CREDIT_CARD",
+          "ADDRESS",
           "DATE_TIME",
+          "DOMAIN",
+          "DRIVER_LICENSE",
           "EMAIL_ADDRESS",
-          "IBAN_CODE",
+          "FINANCIAL",
+          "GPE",
           "IP_ADDRESS",
           "LOCATION",
-          "NRP",
+          "NATIONALITY",
+          "ORGANIZATION",
           "PERSON",
           "PHONE_NUMBER",
+          "SSN",
           "URL",
-          "US_DRIVER_LICENSE",
-          "US_SSN",
           "O",
           "Total"
          ],
          "yaxis": "y",
          "z": {
-          "bdata": "aQALAAAAAAAAAAAAAAAAAAEAAAAAAAAAEwCIAAAAnQAAAAAAAAAAAAAAAAAAAAAAAAAAACQAwQAAAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAAAAAAFQAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAAAAAAAAADQAAAAAAAQAAAAAAAAAAAAAADgAAAAYAAAAAAAAAfQAAABQAAAAAAAAAAAABApgCAAAAAAAAAAAAAAEAIAAAAAAAAAAAAAAAFgA3AAAAAAAAAAAAAAALAAEArQEAAAAAAAAAAN4AlwIAAAQAAAAAAAAAAAAAAAAAEwAAAAAAAAA0AEsAAAAAAAAAAAAAAAAAAAAAAAAAJQAAAAAAAAAlAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAC+AAAAAAAAAMgAGQD/ABIAAAAAAAAAAACwAmkAcAExABUADQBRAToAwQInACUABAAQAGADOAo=",
+          "bdata": "AAAZAAAAAAAAAAAAAAAAABQAAAAAAAoAAAAAAAAA1gENAgAAnQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAwQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJQAAACUAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAAAMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAsAAAAAAAAAfgAAAAAAAAAAAAAAAAABAAAAAAATAJ0AAAABAAAAAAAAAAAAAAAAAH8AAAAAAA0AAAAAAAAAyQBWAQAAAAAAAAAAAAAAAAAADQAAAAAAAAABAAAAAAAAAAAADgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAIAAAAAAAAAAAAAAAFgA3AAAAAAAAAAAAAAAAAAAAAAALAAIAAAARAAAAAAAAAMUA4wAAAAAAAAAAAAAAAAAAAAAADAABAAAAqgEAAAAAAAD8ALMCAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAEwAAAAAANABLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC2AAAAAAAAAAAAAAAAALcAFwAAAD0BEgAAAAAAAADTAgAAfAEAAAQAMQB+AAAADQBiAToAAAAQAycAEAAlAOEEJQw=",
           "dtype": "i2",
-          "shape": "14, 14"
+          "shape": "17, 17"
          }
         }
        ],
@@ -4451,7 +4765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "a408f03e-a014-4631-923f-00cc9d6e08e7",
    "metadata": {
     "ExecuteTime": {
@@ -4471,15 +4785,15 @@
          "bingroup": "y",
          "cliponaxis": true,
          "histfunc": "sum",
-         "hovertemplate": "annotation=LOCATION<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "LOCATION",
+         "hovertemplate": "annotation=ORGANIZATION<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "ORGANIZATION",
          "marker": {
           "color": "#EF553B",
           "pattern": {
            "shape": ""
           }
          },
-         "name": "LOCATION",
+         "name": "ORGANIZATION",
          "orientation": "h",
          "showlegend": true,
          "textangle": 0,
@@ -4490,16 +4804,16 @@
          "texttemplate": "%{value}",
          "type": "histogram",
          "x": {
-          "bdata": "DQMDAwM=",
+          "bdata": "BAQEAwM=",
           "dtype": "i1"
          },
          "xaxis": "x",
          "y": [
-          "greenlander",
-          "76400",
-          "grössgstötten 50",
-          "costamezzana 43015",
-          "den haag"
+          "roadify transit",
+          "mhealthcoach",
+          "owens duran oneal",
+          "caspio",
+          "adaptive"
          ],
          "yaxis": "y"
         },
@@ -4507,15 +4821,61 @@
          "bingroup": "y",
          "cliponaxis": true,
          "histfunc": "sum",
-         "hovertemplate": "annotation=NRP<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "NRP",
+         "hovertemplate": "annotation=ADDRESS<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "ADDRESS",
          "marker": {
           "color": "#00cc96",
           "pattern": {
            "shape": ""
           }
          },
-         "name": "NRP",
+         "name": "ADDRESS",
+         "orientation": "h",
+         "showlegend": true,
+         "textangle": 0,
+         "textfont": {
+          "size": 6
+         },
+         "textposition": "outside",
+         "texttemplate": "%{value}",
+         "type": "histogram",
+         "x": {
+          "bdata": "AwMDAwMDAwMDAwMDAwMD",
+          "dtype": "i1"
+         },
+         "xaxis": "x",
+         "y": [
+          "c. beerninckstraat 88",
+          "76400",
+          "grössgstötten 50",
+          "hanne ul więckowskiego stefana 28",
+          "hansinegata 120",
+          "c. beerninckstraat 88",
+          "76400",
+          "grössgstötten 50",
+          "hanne ul więckowskiego stefana 28",
+          "hansinegata 120",
+          "isaac lodge",
+          "joaquin suarez 2906",
+          "marina fort",
+          "merineitsi põik 87 van gijn summit \n  364 \n  melliste \n  estonia 02561",
+          "nuova del campo 85 baranyay mill"
+         ],
+         "yaxis": "y"
+        },
+        {
+         "bingroup": "y",
+         "cliponaxis": true,
+         "histfunc": "sum",
+         "hovertemplate": "annotation=NATIONALITY<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "NATIONALITY",
+         "marker": {
+          "color": "#ab63fa",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "NATIONALITY",
          "orientation": "h",
          "showlegend": true,
          "textangle": 0,
@@ -4531,10 +4891,10 @@
          },
          "xaxis": "x",
          "y": [
-          "brazil",
           "english",
-          "greenlander",
+          "brazil",
           "spanish",
+          "greenlander",
           "russian"
          ],
          "yaxis": "y"
@@ -4546,7 +4906,7 @@
          "hovertemplate": "annotation=DATE_TIME<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
          "legendgroup": "DATE_TIME",
          "marker": {
-          "color": "#ab63fa",
+          "color": "#FFA15A",
           "pattern": {
            "shape": ""
           }
@@ -4569,9 +4929,9 @@
          "y": [
           "66",
           "60",
+          "1970 09 29 20:21:24",
           "1970 09 24 09:34:31",
-          "41",
-          "2018 02 24 12:45:18"
+          "1971 09 07 22:49:16"
          ],
          "yaxis": "y"
         },
@@ -4582,7 +4942,7 @@
          "hovertemplate": "annotation=PERSON<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
          "legendgroup": "PERSON",
          "marker": {
-          "color": "#FFA15A",
+          "color": "#19d3f3",
           "pattern": {
            "shape": ""
           }
@@ -4604,10 +4964,10 @@
          "xaxis": "x",
          "y": [
           "selma",
-          "leigha mackay",
+          "csanád",
           "josefsen",
-          "nyberg",
-          "vitoria"
+          "fletcher hill",
+          "antonio"
          ],
          "yaxis": "y"
         },
@@ -4615,15 +4975,51 @@
          "bingroup": "y",
          "cliponaxis": true,
          "histfunc": "sum",
-         "hovertemplate": "annotation=CREDIT_CARD<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "CREDIT_CARD",
+         "hovertemplate": "annotation=GPE<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "GPE",
          "marker": {
-          "color": "#19d3f3",
+          "color": "#FF6692",
           "pattern": {
            "shape": ""
           }
          },
-         "name": "CREDIT_CARD",
+         "name": "GPE",
+         "orientation": "h",
+         "showlegend": true,
+         "textangle": 0,
+         "textfont": {
+          "size": 6
+         },
+         "textposition": "outside",
+         "texttemplate": "%{value}",
+         "type": "histogram",
+         "x": {
+          "bdata": "GRgODQ0=",
+          "dtype": "i1"
+         },
+         "xaxis": "x",
+         "y": [
+          "estonia",
+          "norway",
+          "canada",
+          "greenlander",
+          "czech republic"
+         ],
+         "yaxis": "y"
+        },
+        {
+         "bingroup": "y",
+         "cliponaxis": true,
+         "histfunc": "sum",
+         "hovertemplate": "annotation=FINANCIAL<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "FINANCIAL",
+         "marker": {
+          "color": "#B6E880",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "FINANCIAL",
          "orientation": "h",
          "showlegend": true,
          "textangle": 0,
@@ -4640,9 +5036,9 @@
          "xaxis": "x",
          "y": [
           "060426070011",
-          "4415101282806639538",
-          "4273468222888969924",
-          "4735615260219382870",
+          "213176828496175",
+          "2623322164608847",
+          "4030874397740603788",
           "4064557646766436702"
          ],
          "yaxis": "y"
@@ -4651,15 +5047,15 @@
          "bingroup": "y",
          "cliponaxis": true,
          "histfunc": "sum",
-         "hovertemplate": "annotation=US_DRIVER_LICENSE<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "US_DRIVER_LICENSE",
+         "hovertemplate": "annotation=DRIVER_LICENSE<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "DRIVER_LICENSE",
          "marker": {
-          "color": "#FF6692",
+          "color": "#FF97FF",
           "pattern": {
            "shape": ""
           }
          },
-         "name": "US_DRIVER_LICENSE",
+         "name": "DRIVER_LICENSE",
          "orientation": "h",
          "showlegend": true,
          "textangle": 0,
@@ -4686,7 +5082,7 @@
          "hovertemplate": "annotation=PHONE_NUMBER<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
          "legendgroup": "PHONE_NUMBER",
          "marker": {
-          "color": "#B6E880",
+          "color": "#FECB52",
           "pattern": {
            "shape": ""
           }
@@ -4707,11 +5103,11 @@
          },
          "xaxis": "x",
          "y": [
-          "450 0840",
-          "0961 7596216",
           "0393 1144137",
+          "450 0840",
           "9472 7916",
-          "467 3395"
+          "0961 7596216",
+          "01.84.17.61.18"
          ],
          "yaxis": "y"
         },
@@ -4719,15 +5115,15 @@
          "bingroup": "y",
          "cliponaxis": true,
          "histfunc": "sum",
-         "hovertemplate": "annotation=IP_ADDRESS<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "IP_ADDRESS",
+         "hovertemplate": "annotation=DOMAIN<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "DOMAIN",
          "marker": {
-          "color": "#FF97FF",
+          "color": "#636efa",
           "pattern": {
            "shape": ""
           }
          },
-         "name": "IP_ADDRESS",
+         "name": "DOMAIN",
          "orientation": "h",
          "showlegend": true,
          "textangle": 0,
@@ -4738,19 +5134,23 @@
          "texttemplate": "%{value}",
          "type": "histogram",
          "x": {
-          "bdata": "Aw==",
+          "bdata": "AwMDAwM=",
           "dtype": "i1"
          },
          "xaxis": "x",
          "y": [
-          "172.61.42.192"
+          "http://anonymousear.fr/",
+          "http://celebrityforeclosures.cz/",
+          "http://poolvendor.be/",
+          "http://smellology.be/",
+          "http://stellarlistings.es/"
          ],
          "yaxis": "y"
         }
        ],
        "layout": {
         "barmode": "relative",
-        "height": 1710,
+        "height": 2580,
         "legend": {
          "title": {
           "text": "annotation"
@@ -5579,15 +5979,15 @@
          "bingroup": "y",
          "cliponaxis": true,
          "histfunc": "sum",
-         "hovertemplate": "prediction=LOCATION<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "LOCATION",
+         "hovertemplate": "prediction=NATIONALITY<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "NATIONALITY",
          "marker": {
           "color": "#636efa",
           "pattern": {
            "shape": ""
           }
          },
-         "name": "LOCATION",
+         "name": "NATIONALITY",
          "orientation": "h",
          "showlegend": true,
          "textangle": 0,
@@ -5598,52 +5998,16 @@
          "texttemplate": "%{value}",
          "type": "histogram",
          "x": {
-          "bdata": "BwQEBAQ=",
-          "dtype": "i1"
-         },
-         "xaxis": "x",
-         "y": [
-          "cyprus",
-          "hungary",
-          "antonio",
-          "belgium",
-          "austria"
-         ],
-         "yaxis": "y"
-        },
-        {
-         "bingroup": "y",
-         "cliponaxis": true,
-         "histfunc": "sum",
-         "hovertemplate": "prediction=NRP<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
-         "legendgroup": "NRP",
-         "marker": {
-          "color": "#EF553B",
-          "pattern": {
-           "shape": ""
-          }
-         },
-         "name": "NRP",
-         "orientation": "h",
-         "showlegend": true,
-         "textangle": 0,
-         "textfont": {
-          "size": 6
-         },
-         "textposition": "outside",
-         "texttemplate": "%{value}",
-         "type": "histogram",
-         "x": {
-          "bdata": "CgMCAgE=",
+          "bdata": "CgMDAwI=",
           "dtype": "i1"
          },
          "xaxis": "x",
          "y": [
           "greek",
+          "cityscan",
+          "caspio",
           "sokolov",
-          "czech",
-          "russian treaty",
-          "american"
+          "russian treaty"
          ],
          "yaxis": "y"
         },
@@ -5654,7 +6018,7 @@
          "hovertemplate": "prediction=DATE_TIME<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
          "legendgroup": "DATE_TIME",
          "marker": {
-          "color": "#00cc96",
+          "color": "#EF553B",
           "pattern": {
            "shape": ""
           }
@@ -5675,8 +6039,8 @@
          },
          "xaxis": "x",
          "y": [
-          "8",
           "sunday labor",
+          "8",
           "60s",
           "couple",
           "following"
@@ -5690,7 +6054,7 @@
          "hovertemplate": "prediction=PERSON<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
          "legendgroup": "PERSON",
          "marker": {
-          "color": "#ab63fa",
+          "color": "#00cc96",
           "pattern": {
            "shape": ""
           }
@@ -5706,16 +6070,52 @@
          "texttemplate": "%{value}",
          "type": "histogram",
          "x": {
-          "bdata": "DAMDAwM=",
+          "bdata": "DAkJBQU=",
           "dtype": "i1"
          },
          "xaxis": "x",
          "y": [
           "greenlander",
-          "kulusuk",
-          "metallica",
-          "rua diadema 1903",
-          "kaczmarek bonifacy kaczmarek"
+          "margaret s. stouffer kristen rocher panjiva riku andou jeremy hartmann ástríður steinarsdóttir impi nummelin",
+          "rościsław dudek dobrosław tomaszewski owens duran kathrine filemonsen dds yuito hirai abby holloway irena bílá",
+          "parker suknović vladimír jára josef mališ evans bonilla tânia souza",
+          "metallica"
+         ],
+         "yaxis": "y"
+        },
+        {
+         "bingroup": "y",
+         "cliponaxis": true,
+         "histfunc": "sum",
+         "hovertemplate": "prediction=LOCATION<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "LOCATION",
+         "marker": {
+          "color": "#ab63fa",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "LOCATION",
+         "orientation": "h",
+         "showlegend": true,
+         "textangle": 0,
+         "textfont": {
+          "size": 6
+         },
+         "textposition": "outside",
+         "texttemplate": "%{value}",
+         "type": "histogram",
+         "x": {
+          "bdata": "GhkODg0=",
+          "dtype": "i1"
+         },
+         "xaxis": "x",
+         "y": [
+          "norway",
+          "estonia",
+          "sweden",
+          "france",
+          "czech republic"
          ],
          "yaxis": "y"
         },
@@ -5750,15 +6150,51 @@
           "2270 66 1551",
           "060426070011",
           "+1 604 696 5272x565 +41 0)71 526 99 04",
-          "0688 872",
-          "579)888 3058 001 518 640 0854"
+          "+46 0)8 928 571 38",
+          "001 253 366 9781"
+         ],
+         "yaxis": "y"
+        },
+        {
+         "bingroup": "y",
+         "cliponaxis": true,
+         "histfunc": "sum",
+         "hovertemplate": "prediction=URL<br>sum of 0=%{x}<br>token=%{y}<extra></extra>",
+         "legendgroup": "URL",
+         "marker": {
+          "color": "#19d3f3",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "URL",
+         "orientation": "h",
+         "showlegend": true,
+         "textangle": 0,
+         "textfont": {
+          "size": 6
+         },
+         "textposition": "outside",
+         "texttemplate": "%{value}",
+         "type": "histogram",
+         "x": {
+          "bdata": "AwMDAwM=",
+          "dtype": "i1"
+         },
+         "xaxis": "x",
+         "y": [
+          "http://anonymousear.fr/",
+          "http://celebrityforeclosures.cz/",
+          "http://poolvendor.be/",
+          "http://smellology.be/",
+          "http://stellarlistings.es/"
          ],
          "yaxis": "y"
         }
        ],
        "layout": {
         "barmode": "relative",
-        "height": 750,
+        "height": 900,
         "legend": {
          "title": {
           "text": "prediction"
@@ -6592,7 +7028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "640037af",
    "metadata": {
     "ExecuteTime": {
@@ -6606,46 +7042,46 @@
      "output_type": "stream",
      "text": [
       "Most common false positive tokens:\n",
-      "[('8', 15),\n",
+      "[('norway', 18),\n",
+      " ('estonia', 17),\n",
+      " ('8', 15),\n",
       " ('sunday labor', 13),\n",
+      " ('cyprus', 11),\n",
+      " ('hungary', 10),\n",
       " ('greek', 10),\n",
-      " ('60s', 8),\n",
-      " ('greenlander', 8),\n",
-      " ('couple', 7),\n",
-      " ('10th', 7),\n",
-      " ('cyprus', 7),\n",
-      " ('following', 6),\n",
-      " ('hungary', 4)]\n",
+      " ('france', 10),\n",
+      " ('sweden', 10),\n",
+      " ('czech republic', 9)]\n",
       "---------------\n",
       "Example sentence with each FP token:\n",
+      "\t- Norway (`norway` pred as LOCATION)\n",
+      "\t- Estonia (`estonia` pred as LOCATION)\n",
       "\t- 8 + years (`8` pred as DATE_TIME)\n",
       "\t- the last Sunday before Labor Day (`sunday labor` pred as DATE_TIME)\n",
-      "\t- Greek (`greek` pred as NRP)\n",
-      "\t- the 60s (`60s` pred as DATE_TIME)\n",
-      "\t- Greenlander (`greenlander` pred as PERSON)\n",
-      "\t- a couple of months (`couple` pred as DATE_TIME)\n",
-      "\t- 10th year (`10th` pred as DATE_TIME)\n",
       "\t- Cyprus (`cyprus` pred as LOCATION)\n",
-      "\t- the following year (`following` pred as DATE_TIME)\n",
-      "\t- Hungary (`hungary` pred as LOCATION)\n"
+      "\t- Hungary (`hungary` pred as LOCATION)\n",
+      "\t- Greek (`greek` pred as NATIONALITY)\n",
+      "\t- France (`france` pred as LOCATION)\n",
+      "\t- Sweden (`sweden` pred as LOCATION)\n",
+      "\t- Czech Republic (`czech republic` pred as LOCATION)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[('8', 15),\n",
+       "[('norway', 18),\n",
+       " ('estonia', 17),\n",
+       " ('8', 15),\n",
        " ('sunday labor', 13),\n",
+       " ('cyprus', 11),\n",
+       " ('hungary', 10),\n",
        " ('greek', 10),\n",
-       " ('60s', 8),\n",
-       " ('greenlander', 8),\n",
-       " ('couple', 7),\n",
-       " ('10th', 7),\n",
-       " ('cyprus', 7),\n",
-       " ('following', 6),\n",
-       " ('hungary', 4)]"
+       " ('france', 10),\n",
+       " ('sweden', 10),\n",
+       " ('czech republic', 9)]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6669,7 +7105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "f2612275-830f-47ad-aa32-61879b79c57f",
    "metadata": {
     "ExecuteTime": {
@@ -6680,182 +7116,6 @@
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "full_text",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "token",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "annotation",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "prediction",
-         "rawType": "object",
-         "type": "string"
-        }
-       ],
-       "ref": "ef17f1ee-4c1b-4e36-a87c-89da448e8b64",
-       "rows": [
-        [
-         "0",
-         "J Gelencsér ג€",
-         "j gelencsér ג€",
-         "O",
-         "PERSON"
-        ],
-        [
-         "1",
-         "Answer:\"Tube Snake Boogie",
-         "answer:\"tube snake boogie",
-         "O",
-         "PERSON"
-        ],
-        [
-         "2",
-         "Faina D. Yefremova 's",
-         "faina d. yefremova",
-         "O",
-         "PERSON"
-        ],
-        [
-         "3",
-         "Sara Schwarz \n    ",
-         "sara schwarz \n    ",
-         "O",
-         "PERSON"
-        ],
-        [
-         "4",
-         "Rua",
-         "rua",
-         "O",
-         "PERSON"
-        ],
-        [
-         "5",
-         "Verdafero Eklund Michael Hodge",
-         "verdafero eklund michael hodge",
-         "O",
-         "PERSON"
-        ],
-        [
-         "6",
-         "Király u.",
-         "király u.",
-         "O",
-         "PERSON"
-        ],
-        [
-         "7",
-         "Kaczmarek Bonifacy Kaczmarek",
-         "kaczmarek bonifacy kaczmarek",
-         "O",
-         "PERSON"
-        ],
-        [
-         "8",
-         "Kaczmarek Bonifacy Kaczmarek",
-         "kaczmarek bonifacy kaczmarek",
-         "O",
-         "PERSON"
-        ],
-        [
-         "9",
-         "Kaczmarek Bonifacy Kaczmarek",
-         "kaczmarek bonifacy kaczmarek",
-         "O",
-         "PERSON"
-        ],
-        [
-         "10",
-         "Yefimov",
-         "yefimov",
-         "O",
-         "PERSON"
-        ],
-        [
-         "11",
-         "Janka M. Szász",
-         "janka m. szász",
-         "O",
-         "PERSON"
-        ],
-        [
-         "12",
-         "Jožef Albin Jožef Albin København",
-         "jožef albin jožef albin københavn",
-         "O",
-         "PERSON"
-        ],
-        [
-         "13",
-         "Jožef Albin Jožef Albin København",
-         "jožef albin jožef albin københavn",
-         "O",
-         "PERSON"
-        ],
-        [
-         "14",
-         "Flateyri",
-         "flateyri",
-         "O",
-         "PERSON"
-        ],
-        [
-         "15",
-         "Glyn St",
-         "glyn",
-         "O",
-         "PERSON"
-        ],
-        [
-         "16",
-         "Marie Langrová",
-         "marie langrová",
-         "O",
-         "PERSON"
-        ],
-        [
-         "17",
-         "Kyle Kuefer",
-         "kyle kuefer",
-         "O",
-         "PERSON"
-        ],
-        [
-         "18",
-         "Davis Reynolds",
-         "davis reynolds",
-         "O",
-         "PERSON"
-        ],
-        [
-         "19",
-         "Kevin Veitonen II",
-         "kevin veitonen ii",
-         "O",
-         "PERSON"
-        ]
-       ],
-       "shape": {
-        "columns": 4,
-        "rows": 20
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -6926,15 +7186,15 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>Király u.</td>\n",
-       "      <td>király u.</td>\n",
+       "      <td>Verdafero Eklund Michael Hodge</td>\n",
+       "      <td>verdafero eklund michael hodge</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>Kaczmarek Bonifacy Kaczmarek</td>\n",
-       "      <td>kaczmarek bonifacy kaczmarek</td>\n",
+       "      <td>Király u.</td>\n",
+       "      <td>király u.</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
@@ -6954,22 +7214,22 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
+       "      <td>Kaczmarek Bonifacy Kaczmarek</td>\n",
+       "      <td>kaczmarek bonifacy kaczmarek</td>\n",
+       "      <td>O</td>\n",
+       "      <td>PERSON</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
        "      <td>Yefimov</td>\n",
        "      <td>yefimov</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11</th>\n",
+       "      <th>12</th>\n",
        "      <td>Janka M. Szász</td>\n",
        "      <td>janka m. szász</td>\n",
-       "      <td>O</td>\n",
-       "      <td>PERSON</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>Jožef Albin Jožef Albin København</td>\n",
-       "      <td>jožef albin jožef albin københavn</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
@@ -6982,43 +7242,43 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>14</th>\n",
+       "      <td>Jožef Albin Jožef Albin København</td>\n",
+       "      <td>jožef albin jožef albin københavn</td>\n",
+       "      <td>O</td>\n",
+       "      <td>PERSON</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>Jožef Albin Jožef Albin København</td>\n",
+       "      <td>jožef albin jožef albin københavn</td>\n",
+       "      <td>O</td>\n",
+       "      <td>PERSON</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
        "      <td>Flateyri</td>\n",
        "      <td>flateyri</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>15</th>\n",
+       "      <th>17</th>\n",
        "      <td>Glyn St</td>\n",
        "      <td>glyn</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>Marie Langrová</td>\n",
-       "      <td>marie langrová</td>\n",
-       "      <td>O</td>\n",
-       "      <td>PERSON</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>Kyle Kuefer</td>\n",
-       "      <td>kyle kuefer</td>\n",
-       "      <td>O</td>\n",
-       "      <td>PERSON</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>18</th>\n",
-       "      <td>Davis Reynolds</td>\n",
-       "      <td>davis reynolds</td>\n",
+       "      <td>Metallica</td>\n",
+       "      <td>metallica</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
-       "      <td>Kevin Veitonen II</td>\n",
-       "      <td>kevin veitonen ii</td>\n",
+       "      <td>Marie Langrová</td>\n",
+       "      <td>marie langrová</td>\n",
        "      <td>O</td>\n",
        "      <td>PERSON</td>\n",
        "    </tr>\n",
@@ -7034,20 +7294,20 @@
        "3                 Sara Schwarz \\n                    sara schwarz \\n       \n",
        "4                                 Rua                                rua   \n",
        "5      Verdafero Eklund Michael Hodge     verdafero eklund michael hodge   \n",
-       "6                           Király u.                          király u.   \n",
-       "7        Kaczmarek Bonifacy Kaczmarek       kaczmarek bonifacy kaczmarek   \n",
+       "6      Verdafero Eklund Michael Hodge     verdafero eklund michael hodge   \n",
+       "7                           Király u.                          király u.   \n",
        "8        Kaczmarek Bonifacy Kaczmarek       kaczmarek bonifacy kaczmarek   \n",
        "9        Kaczmarek Bonifacy Kaczmarek       kaczmarek bonifacy kaczmarek   \n",
-       "10                            Yefimov                            yefimov   \n",
-       "11                     Janka M. Szász                     janka m. szász   \n",
-       "12  Jožef Albin Jožef Albin København  jožef albin jožef albin københavn   \n",
+       "10       Kaczmarek Bonifacy Kaczmarek       kaczmarek bonifacy kaczmarek   \n",
+       "11                            Yefimov                            yefimov   \n",
+       "12                     Janka M. Szász                     janka m. szász   \n",
        "13  Jožef Albin Jožef Albin København  jožef albin jožef albin københavn   \n",
-       "14                           Flateyri                           flateyri   \n",
-       "15                            Glyn St                               glyn   \n",
-       "16                     Marie Langrová                     marie langrová   \n",
-       "17                        Kyle Kuefer                        kyle kuefer   \n",
-       "18                     Davis Reynolds                     davis reynolds   \n",
-       "19                  Kevin Veitonen II                  kevin veitonen ii   \n",
+       "14  Jožef Albin Jožef Albin København  jožef albin jožef albin københavn   \n",
+       "15  Jožef Albin Jožef Albin København  jožef albin jožef albin københavn   \n",
+       "16                           Flateyri                           flateyri   \n",
+       "17                            Glyn St                               glyn   \n",
+       "18                          Metallica                          metallica   \n",
+       "19                     Marie Langrová                     marie langrová   \n",
        "\n",
        "   annotation prediction  \n",
        "0           O     PERSON  \n",
@@ -7072,7 +7332,7 @@
        "19          O     PERSON  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7095,7 +7355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "afae40fc",
    "metadata": {
     "ExecuteTime": {
@@ -7109,61 +7369,61 @@
      "output_type": "stream",
      "text": [
       "Most common false negative tokens:\n",
-      "[('greenlander', 11),\n",
-      " ('english', 3),\n",
-      " ('selma', 3),\n",
-      " ('brazil', 3),\n",
-      " ('tunisia', 2),\n",
-      " ('2270 66 1551', 2),\n",
-      " ('canada', 2),\n",
-      " ('flateyri', 2),\n",
-      " ('60', 2),\n",
-      " ('17151 2450 crown', 2),\n",
-      " ('2623322164608847', 2),\n",
-      " ('213176828496175', 2),\n",
-      " ('41086 kiannonkatu 98 464 oulu finland 80896', 2),\n",
-      " ('joaquin suarez 2906', 2),\n",
-      " ('hanne ul więckowskiego stefana 28', 2)]\n",
+      "[('estonia', 17),\n",
+      " ('norway', 16),\n",
+      " ('greenlander', 11),\n",
+      " ('canada', 10),\n",
+      " ('czech republic', 9),\n",
+      " ('france', 8),\n",
+      " ('united states', 8),\n",
+      " ('iceland', 8),\n",
+      " ('sweden', 8),\n",
+      " ('hungary', 7),\n",
+      " ('tunisia', 6),\n",
+      " ('finland', 6),\n",
+      " ('uruguay', 6),\n",
+      " ('austria', 5),\n",
+      " ('poland', 5)]\n",
       "---------------\n",
       "Example sentence with each FN token:\n",
-      "\t- Greenlander (`greenlander` annotated as LOCATION)\n",
-      "\t- English (`english` annotated as NRP)\n",
-      "\t- Selma (`selma` annotated as PERSON)\n",
-      "\t- Brazil (`brazil` annotated as NRP)\n",
-      "\t- Tunisia (`tunisia` annotated as LOCATION)\n",
-      "\t- 2270 - 66 - 1551 (`2270 66 1551` annotated as US_DRIVER_LICENSE)\n",
-      "\t- Canada (`canada` annotated as LOCATION)\n",
-      "\t- Flateyri (`flateyri` annotated as LOCATION)\n",
-      "\t- 60 (`60` annotated as DATE_TIME)\n",
-      "\t- 17151 2450 Crown St (`17151 2450 crown` annotated as LOCATION)\n",
-      "\t- 2623322164608847 (`2623322164608847` annotated as CREDIT_CARD)\n",
-      "\t- 213176828496175 (`213176828496175` annotated as CREDIT_CARD)\n",
-      "\t- 41086 Kiannonkatu 98 Suite 464 OULU Finland 80896 (`41086 kiannonkatu 98 464 oulu finland 80896` annotated as LOCATION)\n",
-      "\t- Joaquin Suarez 2906 (`joaquin suarez 2906` annotated as LOCATION)\n",
-      "\t- Hanne and ul . Więckowskiego Stefana 28 (`hanne ul więckowskiego stefana 28` annotated as LOCATION)\n"
+      "\t- Estonia (`estonia` annotated as GPE)\n",
+      "\t- Norway (`norway` annotated as GPE)\n",
+      "\t- Greenlander (`greenlander` annotated as GPE)\n",
+      "\t- Canada (`canada` annotated as GPE)\n",
+      "\t- Czech Republic (`czech republic` annotated as GPE)\n",
+      "\t- France (`france` annotated as GPE)\n",
+      "\t- United States (`united states` annotated as GPE)\n",
+      "\t- Iceland (`iceland` annotated as GPE)\n",
+      "\t- Sweden (`sweden` annotated as GPE)\n",
+      "\t- Hungary (`hungary` annotated as GPE)\n",
+      "\t- Tunisia (`tunisia` annotated as GPE)\n",
+      "\t- Finland (`finland` annotated as GPE)\n",
+      "\t- Uruguay (`uruguay` annotated as GPE)\n",
+      "\t- Austria (`austria` annotated as GPE)\n",
+      "\t- Poland (`poland` annotated as GPE)\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[('greenlander', 11),\n",
-       " ('english', 3),\n",
-       " ('selma', 3),\n",
-       " ('brazil', 3),\n",
-       " ('tunisia', 2),\n",
-       " ('2270 66 1551', 2),\n",
-       " ('canada', 2),\n",
-       " ('flateyri', 2),\n",
-       " ('60', 2),\n",
-       " ('17151 2450 crown', 2),\n",
-       " ('2623322164608847', 2),\n",
-       " ('213176828496175', 2),\n",
-       " ('41086 kiannonkatu 98 464 oulu finland 80896', 2),\n",
-       " ('joaquin suarez 2906', 2),\n",
-       " ('hanne ul więckowskiego stefana 28', 2)]"
+       "[('estonia', 17),\n",
+       " ('norway', 16),\n",
+       " ('greenlander', 11),\n",
+       " ('canada', 10),\n",
+       " ('czech republic', 9),\n",
+       " ('france', 8),\n",
+       " ('united states', 8),\n",
+       " ('iceland', 8),\n",
+       " ('sweden', 8),\n",
+       " ('hungary', 7),\n",
+       " ('tunisia', 6),\n",
+       " ('finland', 6),\n",
+       " ('uruguay', 6),\n",
+       " ('austria', 5),\n",
+       " ('poland', 5)]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7182,7 +7442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "7abfcbe9",
    "metadata": {
     "ExecuteTime": {
@@ -7198,7 +7458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "9ae73b2e",
    "metadata": {
     "ExecuteTime": {
@@ -7209,182 +7469,6 @@
    "outputs": [
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "full_text",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "token",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "annotation",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "prediction",
-         "rawType": "object",
-         "type": "string"
-        }
-       ],
-       "ref": "7b164dcb-76ee-4b15-866d-1c4f3993a702",
-       "rows": [
-        [
-         "0",
-         "60 - 56 - 85 - 91",
-         "60 56 85 91",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "1",
-         "( 37 ) 788 - 063 063 966",
-         "37 788 063 063 966",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "2",
-         "0490 75 40 81",
-         "0490 75 40 81",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "3",
-         "0494 92 82 32",
-         "0494 92 82 32",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "4",
-         "699 956 915",
-         "699 956 915",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "5",
-         "( 99 ) 645 - 791",
-         "99 645 791",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "6",
-         "467 3395",
-         "467 3395",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "7",
-         "78 651 450",
-         "78 651 450",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "8",
-         "416 60 039 +46 ( 0)8 928 571 38 +1 - 984 - 182 - 0190",
-         "416 60 039 +46 0)8 928 571 38 +1 984 182 0190",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "9",
-         "0688 872 49 99",
-         "0688 872 49 99",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "10",
-         "9472 7916",
-         "9472 7916",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "11",
-         "21 284 698 2548",
-         "21 284 698 2548",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "12",
-         "21 253 109 8211 208 815",
-         "21 253 109 8211 208 815",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "13",
-         "083 564 9312",
-         "083 564 9312",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "14",
-         "01.84.17.61.18",
-         "01.84.17.61.18",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "15",
-         "451 5986",
-         "451 5986",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "16",
-         "99 668472",
-         "99 668472",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "17",
-         "358 0594",
-         "358 0594",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "18",
-         "0393 1144137",
-         "0393 1144137",
-         "PHONE_NUMBER",
-         "O"
-        ],
-        [
-         "19",
-         "72 128 827",
-         "72 128 827",
-         "PHONE_NUMBER",
-         "O"
-        ]
-       ],
-       "shape": {
-        "columns": 4,
-        "rows": 20
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -7601,7 +7685,7 @@
        "19                                     72 128 827  PHONE_NUMBER          O  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7609,11 +7693,19 @@
    "source": [
     "fns_df[[\"full_text\", \"token\", \"annotation\", \"prediction\"]].head(20)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd344fd2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "presidio-evaluator-zWEOxRfL-py3.13",
+   "display_name": "presidio",
    "language": "python",
    "name": "python3"
   },
@@ -7627,7 +7719,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
+++ b/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "574abb285875c503",
    "metadata": {
     "ExecuteTime": {
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "f4cbd55c",
    "metadata": {
     "ExecuteTime": {
@@ -105,7 +105,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "tokenizing input:   0%|          | 1/1500 [00:00<04:54,  5.08it/s]"
+      "tokenizing input:   0%|          | 0/1500 [00:00<?, ?it/s]"
      ]
     },
     {
@@ -119,7 +119,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "tokenizing input: 100%|██████████| 1500/1500 [00:05<00:00, 292.45it/s]"
+      "tokenizing input: 100%|██████████| 1500/1500 [00:05<00:00, 261.07it/s]"
      ]
     },
     {
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "c164ea07",
    "metadata": {
     "ExecuteTime": {
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "77aedae6",
    "metadata": {
     "ExecuteTime": {
@@ -246,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "313b508f-e901-40b9-b575-c7fb8a794652",
    "metadata": {
     "ExecuteTime": {
@@ -256,9 +256,38 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:presidio-analyzer:Failed to enable GPU (cuda), falling back to CPU: Cannot use GPU, CuPy is not installed\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c12303ca0c44011891e5ec1c2734ffd",
+       "model_id": "080314abe22543c19177a8b92f8b9ae6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n",
+      "WARNING:huggingface_hub.utils._http:Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d0ec96eb48945aba447b7c9760a621f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -272,7 +301,21 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cf05c02d73d6469c86c53baeab331742",
+       "model_id": "f7fcbd7acdbc4fdbba18a6267e757d77",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/174 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a0db918f147e4c2b8bcdc9adabfc3abb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -286,7 +329,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa24fddbda38477db41f035067923f7d",
+       "model_id": "b8533ac2fdba4a27aff52f31a1e1e50e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -300,7 +343,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7eb312ef3562471a9c45ac04a8f8100d",
+       "model_id": "daad79e762a5438cad0bfebe5229cd03",
        "version_major": 2,
        "version_minor": 0
       },
@@ -310,13 +353,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Device set to use cpu\n"
-     ]
     }
    ],
    "source": [
@@ -415,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "0131e028-ac1a-443a-9500-8bada02f39e2",
    "metadata": {
     "ExecuteTime": {
@@ -423,7 +459,25 @@
      "start_time": "2025-07-24T20:22:32.486646Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: pl, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - EsNifRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - EsNieRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItDriverLicenseRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItFiscalCodeRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItVatCodeRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItIdentityCardRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItPassportRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - PlPeselRecognizer supported languages: pl, registry supported languages: en\n"
+     ]
+    }
+   ],
    "source": [
     "def get_titles_recognizer():\n",
     "    titles_recognizer = PatternRecognizer(\n",
@@ -499,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "62f6f3a0-6885-4ae3-843e-1905901d82be",
    "metadata": {
     "ExecuteTime": {
@@ -525,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "81a58abd-582b-441c-9d91-88ff6395c6fd",
    "metadata": {
     "ExecuteTime": {
@@ -539,12 +593,12 @@
      "output_type": "stream",
      "text": [
       "'Supported entities for English:'\n",
-      "['EDUCATION_LEVEL', 'US_SSN', 'US_ITIN', 'USER_NAME', 'MEDICAL_LICENSE',\n",
-      " 'IBAN_CODE', 'LICENSE_PLATE', 'SWIFT_CODE', 'GENDER', 'BLOOD_TYPE',\n",
-      " 'IP_ADDRESS', 'PERSON', 'ZIP_CODE', 'ORGANIZATION', 'SEXUALITY', 'CVV',\n",
-      " 'PASSWORD', 'EMAIL_ADDRESS', 'ETHNICITY', 'LOCATION', 'PHONE_NUMBER',\n",
-      " 'EMPLOYMENT_STATUS', 'CREDIT_CARD', 'US_PASSPORT', 'TITLE', 'MAC_ADDRESS',\n",
-      " 'DATE_TIME', 'AGE', 'OCCUPATION', 'US_BANK_NUMBER', 'ID', 'URL']\n",
+      "['USER_NAME', 'TITLE', 'SWIFT_CODE', 'CVV', 'AGE', 'EMPLOYMENT_STATUS',\n",
+      " 'CREDIT_CARD', 'ORGANIZATION', 'OCCUPATION', 'LICENSE_PLATE', 'LOCATION',\n",
+      " 'SEXUALITY', 'ID', 'PHONE_NUMBER', 'IBAN_CODE', 'EMAIL_ADDRESS', 'US_SSN',\n",
+      " 'DATE_TIME', 'ETHNICITY', 'PASSWORD', 'ZIP_CODE', 'MEDICAL_LICENSE',\n",
+      " 'EDUCATION_LEVEL', 'IP_ADDRESS', 'BLOOD_TYPE', 'GENDER', 'URL',\n",
+      " 'US_BANK_NUMBER', 'US_ITIN', 'PERSON', 'MAC_ADDRESS', 'US_PASSPORT']\n",
       "\n",
       "Loaded recognizers for English:\n",
       "['CreditCardRecognizer', 'UsBankRecognizer', 'UsItinRecognizer',\n",
@@ -602,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "c56749c8-7c0e-4c38-91e7-31cafaddd2d5",
    "metadata": {
     "ExecuteTime": {
@@ -634,17 +688,17 @@
       "Entity: LOCATION, Text: Mt. Sinai\n",
       "\n",
       "Analysis explanation:\n",
-      "{'recognizer': 'TransformersRecognizer', 'pattern_name': None, 'pattern': None, 'original_score': 0.9826093316078186, 'score': 0.9826093316078186, 'textual_explanation': \"Identified as LOCATION by Transformers's Named Entity Recognition\", 'score_context_improvement': 0, 'supportive_context_word': '', 'validation_result': None, 'regex_flags': None}\n",
+      "{'recognizer': 'TransformersRecognizer', 'pattern_name': None, 'pattern': None, 'original_score': 0.9826091527938843, 'score': 0.9826091527938843, 'textual_explanation': \"Identified as LOCATION by Transformers's Named Entity Recognition\", 'score_context_improvement': 0, 'supportive_context_word': '', 'validation_result': None, 'regex_flags': None}\n",
       "\n",
       "Entity: ID, Text: 154555\n",
       "\n",
       "Analysis explanation:\n",
-      "{'recognizer': 'TransformersRecognizer', 'pattern_name': None, 'pattern': None, 'original_score': 0.9104402661323547, 'score': 0.9104402661323547, 'textual_explanation': \"Identified as ID by Transformers's Named Entity Recognition\", 'score_context_improvement': 0, 'supportive_context_word': '', 'validation_result': None, 'regex_flags': None}\n",
+      "{'recognizer': 'TransformersRecognizer', 'pattern_name': None, 'pattern': None, 'original_score': 0.9104401469230652, 'score': 0.9104401469230652, 'textual_explanation': \"Identified as ID by Transformers's Named Entity Recognition\", 'score_context_improvement': 0, 'supportive_context_word': '', 'validation_result': None, 'regex_flags': None}\n",
       "\n",
       "Entity: GENDER, Text: female\n",
       "\n",
       "Analysis explanation:\n",
-      "{'recognizer': 'TransformersRecognizer', 'pattern_name': None, 'pattern': None, 'original_score': 0.7678905129432678, 'score': 0.7678905129432678, 'textual_explanation': \"Identified as GENDER by Transformers's Named Entity Recognition\", 'score_context_improvement': 0, 'supportive_context_word': '', 'validation_result': None, 'regex_flags': None}\n"
+      "{'recognizer': 'TransformersRecognizer', 'pattern_name': None, 'pattern': None, 'original_score': 0.7678912281990051, 'score': 0.7678912281990051, 'textual_explanation': \"Identified as GENDER by Transformers's Named Entity Recognition\", 'score_context_improvement': 0, 'supportive_context_word': '', 'validation_result': None, 'regex_flags': None}\n"
      ]
     }
    ],
@@ -661,7 +715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "8076c4c80070f157",
    "metadata": {
     "ExecuteTime": {
@@ -676,7 +730,7 @@
      "text": [
       "--------\n",
       "Entities supported by this Presidio Analyzer instance:\n",
-      "EDUCATION_LEVEL, US_SSN, US_ITIN, USER_NAME, MEDICAL_LICENSE, IBAN_CODE, LICENSE_PLATE, SWIFT_CODE, GENDER, BLOOD_TYPE, IP_ADDRESS, PERSON, ZIP_CODE, ORGANIZATION, SEXUALITY, CVV, PASSWORD, EMAIL_ADDRESS, ETHNICITY, LOCATION, PHONE_NUMBER, EMPLOYMENT_STATUS, CREDIT_CARD, US_PASSPORT, TITLE, MAC_ADDRESS, DATE_TIME, AGE, OCCUPATION, US_BANK_NUMBER, ID, URL\n"
+      "USER_NAME, TITLE, SWIFT_CODE, CVV, AGE, EMPLOYMENT_STATUS, CREDIT_CARD, ORGANIZATION, OCCUPATION, LICENSE_PLATE, LOCATION, SEXUALITY, ID, PHONE_NUMBER, IBAN_CODE, EMAIL_ADDRESS, US_SSN, DATE_TIME, ETHNICITY, PASSWORD, ZIP_CODE, MEDICAL_LICENSE, EDUCATION_LEVEL, IP_ADDRESS, BLOOD_TYPE, GENDER, URL, US_BANK_NUMBER, US_ITIN, PERSON, MAC_ADDRESS, US_PASSPORT\n"
      ]
     }
    ],
@@ -701,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "8a8132c2",
    "metadata": {},
    "outputs": [
@@ -709,93 +763,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 51s, sys: 55.7 s, total: 2min 47s\n",
-      "Wall time: 1min 56s\n"
+      "CPU times: user 45min 55s, sys: 1.06 s, total: 45min 56s\n",
+      "Wall time: 4min 11s\n"
      ]
     },
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "sentence_id",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "token",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "annotation",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "prediction",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "start_indices",
-         "rawType": "int64",
-         "type": "integer"
-        }
-       ],
-       "ref": "9b0dde06-9ae4-4fb7-9cd1-d506000460a2",
-       "rows": [
-        [
-         "0",
-         "0",
-         "The",
-         "O",
-         "O",
-         "0"
-        ],
-        [
-         "1",
-         "0",
-         "address",
-         "O",
-         "O",
-         "4"
-        ],
-        [
-         "2",
-         "0",
-         "of",
-         "O",
-         "O",
-         "12"
-        ],
-        [
-         "3",
-         "0",
-         "Persint",
-         "ORGANIZATION",
-         "PERSON",
-         "15"
-        ],
-        [
-         "4",
-         "0",
-         "is",
-         "O",
-         "O",
-         "23"
-        ]
-       ],
-       "shape": {
-        "columns": 5,
-        "rows": 5
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -876,7 +849,7 @@
        "4            0       is             O          O             23"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -901,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "c1ad6508",
    "metadata": {},
    "outputs": [],
@@ -912,7 +885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 13,
    "id": "8c087d5f",
    "metadata": {},
    "outputs": [
@@ -920,7 +893,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[COUNTRY-FALLBACK] US_BANK_NUMBER -> NATIONAL_ID  ⚠ document type not recognized\n"
+      "WARNING:presidio_evaluator.entity_mapping:[COUNTRY-FALLBACK] US_BANK_NUMBER -> NATIONAL_ID  ⚠ document type not recognized\n"
      ]
     },
     {
@@ -937,87 +910,6 @@
     },
     {
      "data": {
-      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
-       "columns": [
-        {
-         "name": "index",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "sentence_id",
-         "rawType": "int64",
-         "type": "integer"
-        },
-        {
-         "name": "token",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "annotation",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "prediction",
-         "rawType": "object",
-         "type": "string"
-        },
-        {
-         "name": "start_indices",
-         "rawType": "int64",
-         "type": "integer"
-        }
-       ],
-       "ref": "cf133dc3-3a6b-42b9-a7dc-65bfe0e54e25",
-       "rows": [
-        [
-         "0",
-         "0",
-         "The",
-         "O",
-         "O",
-         "0"
-        ],
-        [
-         "1",
-         "0",
-         "address",
-         "O",
-         "O",
-         "4"
-        ],
-        [
-         "2",
-         "0",
-         "of",
-         "O",
-         "O",
-         "12"
-        ],
-        [
-         "3",
-         "0",
-         "Persint",
-         "ORGANIZATION",
-         "PERSON",
-         "15"
-        ],
-        [
-         "4",
-         "0",
-         "is",
-         "O",
-         "O",
-         "23"
-        ]
-       ],
-       "shape": {
-        "columns": 5,
-        "rows": 5
-       }
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -1098,7 +990,7 @@
        "4            0       is             O          O             23"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1112,7 +1004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 14,
    "id": "716b2ad1",
    "metadata": {},
    "outputs": [
@@ -1122,7 +1014,7 @@
        "CanonicalMapper(28 resolved, 0 pending)"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1145,10 +1037,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 15,
    "id": "0cb58b92",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:presidio_evaluator.evaluation.base_evaluator:skip words not provided, using default skip words. If you want the evaluation to not use skip words, pass skip_words=[]\n"
+     ]
+    }
+   ],
    "source": [
     "# Set up the experiment tracker and log model + dataset params\n",
     "experiment = get_experiment_tracker()\n",
@@ -1163,7 +1063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 16,
    "id": "79aa0dc3",
    "metadata": {},
    "outputs": [
@@ -1171,7 +1071,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "saving experiment data to /Users/omrimendels/Documents/github/presidio-research/notebooks/experiment_20260326-001718.json\n"
+      "saving experiment data to /home/noaevag/presidio-research/notebooks/experiment_20260330-000008.json\n"
      ]
     }
    ],
@@ -1199,7 +1099,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 17,
    "id": "5b4d662d-596c-4a69-b3c9-1edcda20cc5b",
    "metadata": {
     "ExecuteTime": {
@@ -1222,8 +1122,8 @@
          "legendgroup": "",
          "marker": {
           "color": {
-           "bdata": "AAAAAABAbEAAAAAAAFiFQAAAAAAAkIJAAAAAAADAXUAAAAAAAKBjQAAAAAAAADVAAAAAAAAAWUAAAAAAACBgQAAAAAAAgElAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+H8=",
-           "dtype": "f8"
+           "bdata": "4gCrAlICdwCdABUAZACBADMAAAAAAAAAAAAAAAAAIAg=",
+           "dtype": "i2"
           },
           "coloraxis": "coloraxis",
           "pattern": {
@@ -2161,8 +2061,8 @@
          "legendgroup": "",
          "marker": {
           "color": {
-           "bdata": "AAAAAABAbEAAAAAAAFiFQAAAAAAAkIJAAAAAAADAXUAAAAAAAKBjQAAAAAAAADVAAAAAAAAAWUAAAAAAACBgQAAAAAAAgElAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+H8=",
-           "dtype": "f8"
+           "bdata": "4gCrAlICdwCdABUAZACBADMAAAAAAAAAAAAAAAAAIAg=",
+           "dtype": "i2"
           },
           "coloraxis": "coloraxis",
           "pattern": {
@@ -3100,8 +3000,8 @@
          "legendgroup": "",
          "marker": {
           "color": {
-           "bdata": "AAAAAABAbEAAAAAAAFiFQAAAAAAAkIJAAAAAAADAXUAAAAAAAKBjQAAAAAAAADVAAAAAAAAAWUAAAAAAACBgQAAAAAAAgElAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+H8=",
-           "dtype": "f8"
+           "bdata": "4gCrAlICdwCdABUAZACBADMAAAAAAAAAAAAAAAAAIAg=",
+           "dtype": "i2"
           },
           "coloraxis": "coloraxis",
           "pattern": {
@@ -4036,7 +3936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 18,
    "id": "21d8adcebed8fbac",
    "metadata": {
     "ExecuteTime": {
@@ -4083,7 +3983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 19,
    "id": "97e5ccad48ec8d35",
    "metadata": {
     "ExecuteTime": {
@@ -5022,7 +4922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 20,
    "id": "cfe3b38d440148cf",
    "metadata": {
     "ExecuteTime": {
@@ -5066,11 +4966,11 @@
          },
          "xaxis": "x",
          "y": [
-          "owens duran oneal",
           "allianz",
-          "morgan stanley",
-          "garcia roberson",
-          "glover ruiz armstrong"
+          "owens duran oneal",
+          "avalara",
+          "48 factoring",
+          "dun bradstreet"
          ],
          "yaxis": "y"
         },
@@ -5102,11 +5002,11 @@
          },
          "xaxis": "x",
          "y": [
-          "fumigator",
-          "rolling machine operator",
-          "x ray technician",
+          "biomedical engineer",
           "midwife",
-          "singer"
+          "x ray technician",
+          "rolling machine operator",
+          "passenger booking clerk"
          ],
          "yaxis": "y"
         },
@@ -5140,9 +5040,9 @@
          "y": [
           "estonia",
           "greenlander",
-          "staxroith",
-          "75534 030",
-          "maarit hersnapvej 75"
+          "3520",
+          "8592",
+          "cinzia hammarvägen 15"
          ],
          "yaxis": "y"
         },
@@ -5176,8 +5076,8 @@
          "y": [
           "thursday",
           "tuesday",
-          "monday",
           "saturday",
+          "monday",
           "friday"
          ],
          "yaxis": "y"
@@ -5279,9 +5179,9 @@
          "y": [
           "01.84.17.61.18",
           "079 0442 1744",
-          "21 253 109 8211 208 815",
-          "99 577450 +1 604 696 5272x565 +41 0)71 526 99 04",
-          "781 1704 579)888 3058 001 518 640 0854"
+          "024 971 50 30",
+          "0341 8387176 +41 0)85 806 98 67 463 612 6138x036",
+          "03.93.92.16.85 +41 0)96 471 07 95 9498777106"
          ],
          "yaxis": "y"
         },
@@ -5317,7 +5217,7 @@
           "czech",
           "english",
           "spanish",
-          "russian"
+          "swedish"
          ],
          "yaxis": "y"
         }
@@ -6181,7 +6081,7 @@
           "greenlander",
           "staxroith",
           "fernandez",
-          "arpin"
+          "butler peters"
          ],
          "yaxis": "y"
         },
@@ -6216,8 +6116,8 @@
           "royal",
           "estonia",
           "metallica",
-          "danish",
-          "chechen"
+          "benito bianchi benito bianchi",
+          "alberico rizzo barnett melton garcia alberico rizzo"
          ],
          "yaxis": "y"
         },
@@ -6356,7 +6256,7 @@
          "xaxis": "x",
          "y": [
           "079 0442 1744",
-          "+447700 921 916"
+          "+447700677662"
          ],
          "yaxis": "y"
         },
@@ -6389,10 +6289,10 @@
          "xaxis": "x",
          "y": [
           "baroque",
-          "dpo",
           "213164126086955",
           "48750",
-          "75534 030"
+          "3520",
+          "213173282369527"
          ],
          "yaxis": "y"
         },
@@ -6426,9 +6326,9 @@
          "y": [
           "+1 604 696 5272x565 +41 0)71 526 99 04",
           "+46 0)8 928 571 38 984 182",
-          "office\\,07700 063 966",
-          "office\\,+447700",
-          "99"
+          "0)38 549 02 90",
+          "0)96 471 07 95 9498777106",
+          "0341"
          ],
          "yaxis": "y"
         },
@@ -6569,7 +6469,7 @@
           "salesperson",
           "zombie",
           "executives",
-          "midwife"
+          "biomedical engineer"
          ],
          "yaxis": "y"
         },
@@ -7541,7 +7441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 21,
    "id": "640037af",
    "metadata": {
     "ExecuteTime": {
@@ -7594,7 +7494,7 @@
        " ('executives', 7)]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7618,7 +7518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "f2612275-830f-47ad-aa32-61879b79c57f",
    "metadata": {
     "ExecuteTime": {
@@ -7626,9 +7526,232 @@
      "start_time": "2025-07-24T20:23:47.520841Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>full_text</th>\n",
+       "      <th>token</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>prediction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Southern Tunisia</td>\n",
+       "      <td>southern tunisia</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>28245 Puruntie 82 Apt . 595</td>\n",
+       "      <td>28245 puruntie 82 595</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Goiânia</td>\n",
+       "      <td>goiânia</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>PSC 0413 Box 8144</td>\n",
+       "      <td>psc 0413 8144</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>74 Diakou Street Suite 680 Kissousa Cyprus 36903</td>\n",
+       "      <td>74 diakou 680 kissousa cyprus 36903</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>UPTON</td>\n",
+       "      <td>upton</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>3482 Via Franscini</td>\n",
+       "      <td>3482 franscini</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1668 Highveld</td>\n",
+       "      <td>1668 highveld</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>999 delmas mp 35739</td>\n",
+       "      <td>999 delmas mp 35739</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>ben hjel club</td>\n",
+       "      <td>ben hjel club</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>25615 Tawastintie 72 Apt . 004</td>\n",
+       "      <td>25615 tawastintie 72 004</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>Hawkins Richardson Santana</td>\n",
+       "      <td>hawkins richardson santana</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>Unit 4719 Box 7394</td>\n",
+       "      <td>4719 7394</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>English</td>\n",
+       "      <td>english</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>4844</td>\n",
+       "      <td>4844</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>Aalborg NO 9100</td>\n",
+       "      <td>aalborg 9100</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>Southern Austria</td>\n",
+       "      <td>southern austria</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>6076</td>\n",
+       "      <td>6076</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>\\n&nbsp;&nbsp;Suite 464 \\n&nbsp;&nbsp;OULU Finland 80896</td>\n",
+       "      <td>\\n&nbsp;&nbsp;464 \\n&nbsp;&nbsp;oulu finland 80896</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>5586</td>\n",
+       "      <td>5586</td>\n",
+       "      <td>O</td>\n",
+       "      <td>LOCATION</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                           full_text  \\\n",
+       "0                                   Southern Tunisia   \n",
+       "1                        28245 Puruntie 82 Apt . 595   \n",
+       "2                                            Goiânia   \n",
+       "3                                  PSC 0413 Box 8144   \n",
+       "4   74 Diakou Street Suite 680 Kissousa Cyprus 36903   \n",
+       "5                                              UPTON   \n",
+       "6                                 3482 Via Franscini   \n",
+       "7                                      1668 Highveld   \n",
+       "8                                999 delmas mp 35739   \n",
+       "9                                      ben hjel club   \n",
+       "10                    25615 Tawastintie 72 Apt . 004   \n",
+       "11                        Hawkins Richardson Santana   \n",
+       "12                                Unit 4719 Box 7394   \n",
+       "13                                           English   \n",
+       "14                                              4844   \n",
+       "15                                   Aalborg NO 9100   \n",
+       "16                                  Southern Austria   \n",
+       "17                                              6076   \n",
+       "18              \\n  Suite 464 \\n  OULU Finland 80896   \n",
+       "19                                              5586   \n",
+       "\n",
+       "                                  token annotation prediction  \n",
+       "0                      southern tunisia          O   LOCATION  \n",
+       "1                 28245 puruntie 82 595          O   LOCATION  \n",
+       "2                               goiânia          O   LOCATION  \n",
+       "3                         psc 0413 8144          O   LOCATION  \n",
+       "4   74 diakou 680 kissousa cyprus 36903          O   LOCATION  \n",
+       "5                                 upton          O   LOCATION  \n",
+       "6                        3482 franscini          O   LOCATION  \n",
+       "7                         1668 highveld          O   LOCATION  \n",
+       "8                   999 delmas mp 35739          O   LOCATION  \n",
+       "9                         ben hjel club          O   LOCATION  \n",
+       "10             25615 tawastintie 72 004          O   LOCATION  \n",
+       "11           hawkins richardson santana          O   LOCATION  \n",
+       "12                            4719 7394          O   LOCATION  \n",
+       "13                              english          O   LOCATION  \n",
+       "14                                 4844          O   LOCATION  \n",
+       "15                         aalborg 9100          O   LOCATION  \n",
+       "16                     southern austria          O   LOCATION  \n",
+       "17                                 6076          O   LOCATION  \n",
+       "18       \\n  464 \\n  oulu finland 80896          O   LOCATION  \n",
+       "19                                 5586          O   LOCATION  "
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "fps_df = ModelError.get_fps_dataframe(results.model_errors, entity=\"AGE\")\n",
+    "fps_df = ModelError.get_fps_dataframe(results.model_errors, entity=\"LOCATION\")\n",
     "fps_df[[\"full_text\", \"token\", \"annotation\", \"prediction\"]].head(20)"
    ]
   },
@@ -7644,7 +7767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "afae40fc",
    "metadata": {
     "ExecuteTime": {
@@ -7652,7 +7775,71 @@
      "start_time": "2025-07-24T20:23:47.580453Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Most common false negative tokens:\n",
+      "[('american', 8),\n",
+      " ('estonia', 7),\n",
+      " ('czech', 7),\n",
+      " ('greenlander', 6),\n",
+      " ('tuesday', 4),\n",
+      " ('english', 4),\n",
+      " ('russian', 4),\n",
+      " ('thursday', 4),\n",
+      " ('saturday', 3),\n",
+      " ('monday', 3),\n",
+      " ('owens duran oneal', 3),\n",
+      " ('allianz', 3),\n",
+      " ('spanish', 3),\n",
+      " ('swedish', 3),\n",
+      " ('persint', 2)]\n",
+      "---------------\n",
+      "Example sentence with each FN token:\n",
+      "\t- American (`american` annotated as DEMOGRAPHIC)\n",
+      "\t- Estonia (`estonia` annotated as LOCATION)\n",
+      "\t- Czech (`czech` annotated as DEMOGRAPHIC)\n",
+      "\t- Greenlander (`greenlander` annotated as DEMOGRAPHIC)\n",
+      "\t- Tuesday (`tuesday` annotated as DATE_TIME)\n",
+      "\t- English (`english` annotated as DEMOGRAPHIC)\n",
+      "\t- Russian (`russian` annotated as DEMOGRAPHIC)\n",
+      "\t- Thursday (`thursday` annotated as DATE_TIME)\n",
+      "\t- Saturday (`saturday` annotated as DATE_TIME)\n",
+      "\t- Monday (`monday` annotated as DATE_TIME)\n",
+      "\t- owens , duran and oneal (`owens duran oneal` annotated as ORGANIZATION)\n",
+      "\t- Allianz (`allianz` annotated as ORGANIZATION)\n",
+      "\t- Spanish (`spanish` annotated as DEMOGRAPHIC)\n",
+      "\t- Swedish (`swedish` annotated as DEMOGRAPHIC)\n",
+      "\t- Persint (`persint` annotated as ORGANIZATION)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[('american', 8),\n",
+       " ('estonia', 7),\n",
+       " ('czech', 7),\n",
+       " ('greenlander', 6),\n",
+       " ('tuesday', 4),\n",
+       " ('english', 4),\n",
+       " ('russian', 4),\n",
+       " ('thursday', 4),\n",
+       " ('saturday', 3),\n",
+       " ('monday', 3),\n",
+       " ('owens duran oneal', 3),\n",
+       " ('allianz', 3),\n",
+       " ('spanish', 3),\n",
+       " ('swedish', 3),\n",
+       " ('persint', 2)]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ModelError.most_common_fn_tokens(results.model_errors, n=15)"
    ]
@@ -7667,7 +7854,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "7abfcbe9",
    "metadata": {
     "ExecuteTime": {
@@ -7682,7 +7869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "9ae73b2e",
    "metadata": {
     "ExecuteTime": {
@@ -7690,15 +7877,268 @@
      "start_time": "2025-07-24T20:23:47.667443Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>full_text</th>\n",
+       "      <th>token</th>\n",
+       "      <th>annotation</th>\n",
+       "      <th>prediction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Christiansen</td>\n",
+       "      <td>christiansen</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Jensen</td>\n",
+       "      <td>jensen</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Kaczmarek</td>\n",
+       "      <td>kaczmarek</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bonifacy Kaczmarek</td>\n",
+       "      <td>bonifacy kaczmarek</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Meza</td>\n",
+       "      <td>meza</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Janka M. Szász Network and computer systems administrator</td>\n",
+       "      <td>janka m. szász network computer systems administrator</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Marie Langrová Packager</td>\n",
+       "      <td>marie langrová packager</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Hijacinta Godina Technical writer</td>\n",
+       "      <td>hijacinta godina technical writer</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Marcela</td>\n",
+       "      <td>marcela</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>Julieta S Almeida Staff development specialist</td>\n",
+       "      <td>julieta s almeida staff development specialist</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>Zoe Young</td>\n",
+       "      <td>zoe young</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>Rolling machine operator</td>\n",
+       "      <td>rolling machine operator</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>Ella H. Snider</td>\n",
+       "      <td>ella h. snider</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>Ella H. Snider</td>\n",
+       "      <td>ella h. snider</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>Gyala Antall</td>\n",
+       "      <td>gyala antall</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>Gyala Antall</td>\n",
+       "      <td>gyala antall</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>nina</td>\n",
+       "      <td>nina</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>Karin M. Beike Leasing consultant</td>\n",
+       "      <td>karin m. beike leasing consultant</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>naomi ryan sewer pipe cleaner</td>\n",
+       "      <td>naomi ryan sewer pipe cleaner</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>Jarmila Chloupková</td>\n",
+       "      <td>jarmila chloupková</td>\n",
+       "      <td>PERSON</td>\n",
+       "      <td>O</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                    full_text  \\\n",
+       "0                                                Christiansen   \n",
+       "1                                                      Jensen   \n",
+       "2                                                   Kaczmarek   \n",
+       "3                                          Bonifacy Kaczmarek   \n",
+       "4                                                        Meza   \n",
+       "5   Janka M. Szász Network and computer systems administrator   \n",
+       "6                                     Marie Langrová Packager   \n",
+       "7                           Hijacinta Godina Technical writer   \n",
+       "8                                                     Marcela   \n",
+       "9              Julieta S Almeida Staff development specialist   \n",
+       "10                                                  Zoe Young   \n",
+       "11                                   Rolling machine operator   \n",
+       "12                                             Ella H. Snider   \n",
+       "13                                             Ella H. Snider   \n",
+       "14                                               Gyala Antall   \n",
+       "15                                               Gyala Antall   \n",
+       "16                                                       nina   \n",
+       "17                          Karin M. Beike Leasing consultant   \n",
+       "18                              naomi ryan sewer pipe cleaner   \n",
+       "19                                         Jarmila Chloupková   \n",
+       "\n",
+       "                                                    token annotation  \\\n",
+       "0                                            christiansen     PERSON   \n",
+       "1                                                  jensen     PERSON   \n",
+       "2                                               kaczmarek     PERSON   \n",
+       "3                                      bonifacy kaczmarek     PERSON   \n",
+       "4                                                    meza     PERSON   \n",
+       "5   janka m. szász network computer systems administrator     PERSON   \n",
+       "6                                 marie langrová packager     PERSON   \n",
+       "7                       hijacinta godina technical writer     PERSON   \n",
+       "8                                                 marcela     PERSON   \n",
+       "9          julieta s almeida staff development specialist     PERSON   \n",
+       "10                                              zoe young     PERSON   \n",
+       "11                               rolling machine operator     PERSON   \n",
+       "12                                         ella h. snider     PERSON   \n",
+       "13                                         ella h. snider     PERSON   \n",
+       "14                                           gyala antall     PERSON   \n",
+       "15                                           gyala antall     PERSON   \n",
+       "16                                                   nina     PERSON   \n",
+       "17                      karin m. beike leasing consultant     PERSON   \n",
+       "18                          naomi ryan sewer pipe cleaner     PERSON   \n",
+       "19                                     jarmila chloupková     PERSON   \n",
+       "\n",
+       "   prediction  \n",
+       "0           O  \n",
+       "1           O  \n",
+       "2           O  \n",
+       "3           O  \n",
+       "4           O  \n",
+       "5           O  \n",
+       "6           O  \n",
+       "7           O  \n",
+       "8           O  \n",
+       "9           O  \n",
+       "10          O  \n",
+       "11          O  \n",
+       "12          O  \n",
+       "13          O  \n",
+       "14          O  \n",
+       "15          O  \n",
+       "16          O  \n",
+       "17          O  \n",
+       "18          O  \n",
+       "19          O  "
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fns_df[[\"full_text\", \"token\", \"annotation\", \"prediction\"]].head(20)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af25de5f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "presidio",
    "language": "python",
    "name": "python3"
   },
@@ -7712,7 +8152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
+++ b/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
@@ -7518,7 +7518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "f2612275-830f-47ad-aa32-61879b79c57f",
    "metadata": {
     "ExecuteTime": {
@@ -7751,8 +7751,11 @@
     }
    ],
    "source": [
+    "# Pick an entity that has false positives — check the most_common_fp_tokens output\n",
+    "# above to see which entities appear. Returns None if the entity has no FPs.\n",
     "fps_df = ModelError.get_fps_dataframe(results.model_errors, entity=\"LOCATION\")\n",
-    "fps_df[[\"full_text\", \"token\", \"annotation\", \"prediction\"]].head(20)"
+    "if fps_df is not None:\n",
+    "    fps_df[[\"full_text\", \"token\", \"annotation\", \"prediction\"]].head(20)"
    ]
   },
   {

--- a/notebooks/6_Interactive_Entity_Mapping.ipynb
+++ b/notebooks/6_Interactive_Entity_Mapping.ipynb
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "9d38e995",
    "metadata": {},
    "outputs": [
@@ -91,7 +91,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "tokenizing input: 100%|██████████| 1500/1500 [00:04<00:00, 337.86it/s]"
+      "tokenizing input: 100%|██████████| 1500/1500 [00:05<00:00, 279.70it/s]"
      ]
     },
     {
@@ -139,10 +139,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "e1eb357f",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:presidio-analyzer:Failed to enable GPU (cuda), falling back to CPU: Cannot use GPU, CuPy is not installed\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - CreditCardRecognizer supported languages: pl, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - EsNifRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - EsNieRecognizer supported languages: es, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItDriverLicenseRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItFiscalCodeRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItVatCodeRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItIdentityCardRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - ItPassportRecognizer supported languages: it, registry supported languages: en\n",
+      "WARNING:presidio-analyzer:Recognizer not added to registry because language is not supported by registry - PlPeselRecognizer supported languages: pl, registry supported languages: en\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -183,21 +201,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "877bf95e",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[UNRESOLVED] GPE  — no automatic match found\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
-       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">15 exact</span><span style=\"background:#d4a72c;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">1 fuzzy</span><span style=\"background:#cf222e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">1 pending</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#fff1f0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#cf222e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">PENDING</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><em style=\"color:#cf222e\">pending</em></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#fff8c5\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#d4a72c;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">FUZZY</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NAME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">80%</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>TITLE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">17 exact</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>TITLE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -246,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "1f011b7e",
    "metadata": {},
    "outputs": [
@@ -254,14 +265,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Entity Label Mapping  (17 total, 0 pending)\n",
       "\n",
-      "MAPPING: 14 mapped, 3 unmapped | Dataset: 17 active, 0 excluded | Model: 19 entities\n",
-      "\n",
-      "⚠️  UNMAPPED (3):\n",
-      "  • AGE (74 samples)\n",
-      "  • ORGANIZATION (199 samples)\n",
-      "  • TITLE (92 samples)\n",
-      "  💡 You can: 1) map to a model entity, 2) map to None (FN penalty), or 3) exclude them.\n"
+      "Label                          Tier               Canonical                      Score\n",
+      "----------------------------------------------------------------------------------\n",
+      "IP_ADDRESS                     EXACT              IP_ADDRESS                     —\n",
+      "GPE                            EXACT              GPE                            —\n",
+      "DATE_TIME                      EXACT              DATE_TIME                      —\n",
+      "PERSON                         EXACT              PERSON                         —\n",
+      "CREDIT_CARD                    EXACT              FINANCIAL                      —\n",
+      "US_SSN                         EXACT              SSN                            —\n",
+      "STREET_ADDRESS                 EXACT              ADDRESS                        —\n",
+      "PHONE_NUMBER                   EXACT              PHONE_NUMBER                   —\n",
+      "AGE                            EXACT              AGE                            —\n",
+      "TITLE                          EXACT              TITLE                          —\n",
+      "IBAN_CODE                      EXACT              FINANCIAL                      —\n",
+      "NRP                            EXACT              NATIONALITY                    —\n",
+      "ORGANIZATION                   EXACT              ORGANIZATION                   —\n",
+      "DOMAIN_NAME                    EXACT              DOMAIN                         —\n",
+      "EMAIL_ADDRESS                  EXACT              EMAIL_ADDRESS                  —\n",
+      "US_DRIVER_LICENSE              EXACT              DRIVER_LICENSE                 —\n",
+      "ZIP_CODE                       EXACT              ADDRESS                        —\n"
      ]
     }
    ],
@@ -304,26 +328,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "b7193fdf",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ Mapping set: TITLE → None\n",
-      "   (2 entities still unmapped)\n",
-      "\n",
-      "MAPPING: 14 mapped, 2 unmapped | Dataset: 17 active, 0 excluded | Model: 19 entities\n",
-      "\n",
-      "⚠️  UNMAPPED (2):\n",
-      "  • AGE (74 samples)\n",
-      "  • ORGANIZATION (199 samples)\n",
-      "  💡 You can: 1) map to a model entity, 2) map to None (FN penalty), or 3) exclude them.\n",
-      "\n",
-      "🔧 Manual (1): TITLE→None\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">16 exact</span><span style=\"background:#57606a;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">1 none</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#f6f8fa\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#57606a;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">NONE</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><em style=\"color:#57606a\">None</em></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -336,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a7007438",
    "metadata": {},
    "outputs": [
@@ -344,15 +363,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Mapping set: AGE → DATE_TIME\n",
-      "   (1 entities still unmapped)\n",
-      "✓ Mapping set: ORGANIZATION → None\n"
+      "Pending labels: []\n"
      ]
     },
     {
      "data": {
       "text/html": [
-       "<div style=\"font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;\"><h3 style=\"margin-top: 0; color: #24292f;\">🗺️ Entity Mapping Review</h3><div style=\"display: flex; gap: 20px; margin: 15px 0; flex-wrap: wrap;\"><div style=\"background: #f6f8fa; padding: 10px 15px; border-radius: 6px; border: 1px solid #d0d7de;\"><strong>Dataset:</strong> 17 active, 0 excluded</div><div style=\"background: #f6f8fa; padding: 10px 15px; border-radius: 6px; border: 1px solid #d0d7de;\"><strong>Model:</strong> 19 entities</div><div style=\"background: #d1f4e0; padding: 10px 15px; border-radius: 6px; border: 1px solid #a2ddb8;\"><strong>Status:</strong> 15 mapped, 0 unmapped</div></div><details style=\"margin: 15px 0; background: #f6f8fa; padding: 10px; border-radius: 6px; border: 1px solid #d0d7de;\"><summary style=\"cursor: pointer; font-weight: 600; padding: 5px;\">📊 Dataset Entities (17)</summary><div style=\"margin-top: 10px; padding-left: 10px;\"><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">PERSON <span style=\"color: #57606a; font-size: 11px;\">(637 samples, 42.5%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">STREET_ADDRESS <span style=\"color: #57606a; font-size: 11px;\">(348 samples, 23.2%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">GPE <span style=\"color: #57606a; font-size: 11px;\">(325 samples, 21.7%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">ORGANIZATION <span style=\"color: #57606a; font-size: 11px;\">(199 samples, 13.3%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">CREDIT_CARD <span style=\"color: #57606a; font-size: 11px;\">(136 samples, 9.1%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">DATE_TIME <span style=\"color: #57606a; font-size: 11px;\">(119 samples, 7.9%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">TITLE <span style=\"color: #57606a; font-size: 11px;\">(92 samples, 6.1%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">AGE <span style=\"color: #57606a; font-size: 11px;\">(74 samples, 4.9%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">PHONE_NUMBER <span style=\"color: #57606a; font-size: 11px;\">(64 samples, 4.3%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">NRP <span style=\"color: #57606a; font-size: 11px;\">(55 samples, 3.7%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">EMAIL_ADDRESS <span style=\"color: #57606a; font-size: 11px;\">(49 samples, 3.3%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">ZIP_CODE <span style=\"color: #57606a; font-size: 11px;\">(37 samples, 2.5%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">DOMAIN_NAME <span style=\"color: #57606a; font-size: 11px;\">(37 samples, 2.5%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">IBAN_CODE <span style=\"color: #57606a; font-size: 11px;\">(21 samples, 1.4%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_SSN <span style=\"color: #57606a; font-size: 11px;\">(16 samples, 1.1%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">IP_ADDRESS <span style=\"color: #57606a; font-size: 11px;\">(14 samples, 0.9%)</span></span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_DRIVER_LICENSE <span style=\"color: #57606a; font-size: 11px;\">(5 samples, 0.3%)</span></span></div></details><details style=\"margin: 15px 0; background: #f6f8fa; padding: 10px; border-radius: 6px; border: 1px solid #d0d7de;\"><summary style=\"cursor: pointer; font-weight: 600; padding: 5px;\">📦 Model Entities (19)</summary><div style=\"margin-top: 10px; padding-left: 10px;\"><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">CREDIT_CARD</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">CRYPTO</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">DATE_TIME</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">EMAIL_ADDRESS</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">IBAN_CODE</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">IP_ADDRESS</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">LOCATION</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">MAC_ADDRESS</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">MEDICAL_LICENSE</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">NRP</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">PERSON</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">PHONE_NUMBER</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">UK_NHS</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">URL</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_BANK_NUMBER</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_DRIVER_LICENSE</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_ITIN</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_PASSPORT</span><span style=\"display: inline-block; background: #ffffff; border: 1px solid #d0d7de; padding: 4px 8px; margin: 3px; border-radius: 4px; font-family: monospace; font-size: 12px;\">US_SSN</span></div></details><h4 style=\"margin-top: 20px; color: #24292f;\">📋 Entity Mapping</h4><table style=\"width: 100%; border-collapse: collapse; margin: 10px 0; font-size: 13px;\"><thead><tr style=\"background: #f6f8fa; border-bottom: 2px solid #d0d7de;\"><th style=\"padding: 8px; text-align: left; border: 1px solid #d0d7de;\">Dataset Entity</th><th style=\"padding: 8px; text-align: left; border: 1px solid #d0d7de;\">→ Model Entity</th><th style=\"padding: 8px; text-align: center; border: 1px solid #d0d7de;\">Samples</th><th style=\"padding: 8px; text-align: center; border: 1px solid #d0d7de;\">Confidence</th></tr></thead><tbody><tr style=\"background: #f3f4f6; border: 1px solid #d0d7de;\"><td style=\"padding: 8px; border: 1px solid #d0d7de; font-family: monospace; font-weight: 600;\">○ ORGANIZATION</td><td style=\"padding: 8px; border: 1px solid #d0d7de; font-family: monospace;\"><em style='color: #57606a;'>None</em></td><td style=\"padding: 8px; border: 1px solid #d0d7de; text-align: center;\">199</td><td style=\"padding: 8px; border: 1px solid #d0d7de; text-align: center;\"><span style=\"background: #57606a; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">None ✎</span></td></tr><tr style=\"background: #f3f4f6; border: 1px solid #d0d7de;\"><td style=\"padding: 8px; border: 1px solid #d0d7de; font-family: monospace; font-weight: 600;\">○ TITLE</td><td style=\"padding: 8px; border: 1px solid #d0d7de; font-family: monospace;\"><em style='color: #57606a;'>None</em></td><td style=\"padding: 8px; border: 1px solid #d0d7de; text-align: center;\">92</td><td style=\"padding: 8px; border: 1px solid #d0d7de; text-align: center;\"><span style=\"background: #57606a; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">None ✎</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ CREDIT_CARD</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">CREDIT_CARD</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">136</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ DATE_TIME</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">DATE_TIME</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">119</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ DOMAIN_NAME</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">URL</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">37</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ EMAIL_ADDRESS</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">EMAIL_ADDRESS</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">49</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ GPE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">LOCATION</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">325</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ IBAN_CODE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">IBAN_CODE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">21</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ IP_ADDRESS</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">IP_ADDRESS</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">14</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ PERSON</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">PERSON</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">637</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ PHONE_NUMBER</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">PHONE_NUMBER</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">64</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ STREET_ADDRESS</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">LOCATION</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">348</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ US_DRIVER_LICENSE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">US_DRIVER_LICENSE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">5</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ US_SSN</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">US_SSN</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">16</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ ZIP_CODE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">LOCATION</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">37</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ NRP</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">NRP</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">55</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #2da44e; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00</span></td></tr><tr style=\"background: #d1f4e0; border: 1px solid #a2ddb8;\"><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace; font-weight: 600;\">✓ AGE</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; font-family: monospace;\">DATE_TIME</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\">74</td><td style=\"padding: 8px; border: 1px solid #a2ddb8; text-align: center;\"><span style=\"background: #0969da; color: white; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-family: monospace;\">1.00 ✎</span></td></tr></tbody></table><div style=\"margin: 10px 0; padding: 10px; background: #f6f8fa; border-radius: 6px; border: 1px solid #d0d7de; font-size: 12px;\"><strong>Confidence legend:</strong> <span style=\"background: #0969da; color: white; padding: 2px 6px; margin: 0 5px; border-radius: 3px;\">1.00 ✎ Manual</span><span style=\"background: #57606a; color: white; padding: 2px 6px; margin: 0 5px; border-radius: 3px;\">None ✎ Mapped to None</span><span style=\"background: #2da44e; color: white; padding: 2px 6px; margin: 0 5px; border-radius: 3px;\">≥0.70 High</span><span style=\"background: #d4a72c; color: white; padding: 2px 6px; margin: 0 5px; border-radius: 3px;\">0.01-0.69 Low</span><span style=\"background: #cf222e; color: white; padding: 2px 6px; margin: 0 5px; border-radius: 3px;\">0.00 Unmapped</span></div><div style=\"background: #d1f4e0; border: 2px solid #2da44e; padding: 15px; margin: 20px 0; border-radius: 6px;\"><h4 style=\"margin: 0; color: #116329;\">✅ All entities mapped! Ready to run experiment.</h4><p style=\"margin: 10px 0 0 0; color: #116329; font-size: 13px;\">💡 Note: Entities mapped to <code>None</code> will be counted as False Negatives since the model doesn't support them.</p></div></div>"
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">16 exact</span><span style=\"background:#57606a;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">1 none</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#f6f8fa\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#57606a;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">NONE</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><em style=\"color:#57606a\">None</em></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -392,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b42435fd",
    "metadata": {},
    "outputs": [
@@ -400,11 +417,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Entities mapped to None (will become False Negatives):\n",
-      "  • ORGANIZATION: 199 samples → all will be FN\n",
-      "  • TITLE: 92 samples → all will be FN\n",
-      "\n",
-      "Total False Negatives from None mappings: 291\n"
+      "Labels mapped to None: ['TITLE']\n",
+      "Dataset spans affected (will become FN): 92 of 2863\n"
      ]
     }
    ],
@@ -446,20 +460,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "fce0fd07",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Semantic similarity examples:\n",
-      "  FIRST_NAME → DATE_TIME\n",
-      "  STREET_ADDRESS → EMAIL_ADDRESS\n",
-      "  SSN → US_SSN\n",
-      "  BIRTHDAY → PERSON\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">17 exact</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>TITLE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -467,7 +482,7 @@
     "# or add aliases not in the default taxonomy.\n",
     "from presidio_evaluator.entity_mapping import EntityHierarchy\n",
     "\n",
-    "custom_h = EntityHierarchy.default().copy()\n",
+    "custom_h = EntityHierarchy()\n",
     "custom_h.add_alias(\"PERSON\", \"HUMAN_NAME\")  # make HUMAN_NAME resolve to PERSON\n",
     "custom_h.add_alias(\"EMAIL_ADDRESS\", \"E_MAIL\")\n",
     "\n",
@@ -478,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "299966a1",
    "metadata": {},
    "outputs": [
@@ -486,17 +501,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mapping using SemanticEntityMapper:\n",
-      "\n",
-      "MAPPING: 13 mapped, 4 unmapped | Dataset: 17 active, 0 excluded | Model: 19 entities\n",
-      "\n",
-      "⚠️  UNMAPPED (4):\n",
-      "  • AGE (74 samples)\n",
-      "  • GPE (325 samples)\n",
-      "  • ORGANIZATION (199 samples)\n",
-      "  • TITLE (92 samples)\n",
-      "  💡 You can: 1) map to a model entity, 2) map to None (FN penalty), or 3) exclude them.\n"
+      "Pending with threshold=0.65: []\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">17 exact</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>TITLE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -509,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "bbb44a22",
    "metadata": {},
    "outputs": [
@@ -517,16 +535,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "With strict threshold (0.7), fewer entities are auto-mapped:\n",
-      "\n",
-      "MAPPING: 14 mapped, 3 unmapped | Dataset: 17 active, 0 excluded | Model: 19 entities\n",
-      "\n",
-      "⚠️  UNMAPPED (3):\n",
-      "  • AGE (74 samples)\n",
-      "  • ORGANIZATION (199 samples)\n",
-      "  • TITLE (92 samples)\n",
-      "  💡 You can: 1) map to a model entity, 2) map to None (FN penalty), or 3) exclude them.\n"
+      "Pending with canonical_depth=4: []\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif\"><h3 style=\"margin-top:0;color:#24292f\">Entity Label Mapping</h3><div style=\"margin:10px 0\"><span style=\"background:#2da44e;color:white;padding:2px 8px;border-radius:10px;font-size:11px;margin:0 3px\">17 exact</span></div><table style=\"width:100%;border-collapse:collapse;font-size:13px\"><thead><tr style=\"background:#f6f8fa;border-bottom:2px solid #d0d7de\"><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Raw Label</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Tier</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:left\">Canonical</th><th style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">Score</th></tr></thead><tbody><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IP_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>IP_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">GPE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>GPE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DATE_TIME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DATE_TIME</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PERSON</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PERSON</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">CREDIT_CARD</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_SSN</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>SSN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">STREET_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">PHONE_NUMBER</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>PHONE_NUMBER</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">AGE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>AGE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">TITLE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>TITLE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">IBAN_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>FINANCIAL</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">NRP</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>NATIONALITY</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ORGANIZATION</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ORGANIZATION</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">DOMAIN_NAME</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DOMAIN</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">EMAIL_ADDRESS</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>EMAIL_ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">US_DRIVER_LICENSE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>DRIVER_LICENSE</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr><tr style=\"background:#d1f4e0\"><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace;font-weight:600\">ZIP_CODE</td><td style=\"padding:7px 10px;border:1px solid #d0d7de\"><span style=\"background:#2da44e;color:white;padding:1px 6px;border-radius:3px;font-size:11px;font-family:monospace\">EXACT</span></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;font-family:monospace\"><code>ADDRESS</code></td><td style=\"padding:7px 10px;border:1px solid #d0d7de;text-align:center\">—</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -540,40 +562,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "f60964a2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Programmatic mapping with confidence scores:\n",
-      "  AGE                  → None                 (confidence: 0.00)\n",
-      "  CREDIT_CARD          → CREDIT_CARD          (confidence: 1.00)\n",
-      "  DATE_TIME            → DATE_TIME            (confidence: 1.00)\n",
-      "  DOMAIN_NAME          → URL                  (confidence: 1.00)\n",
-      "  EMAIL_ADDRESS        → EMAIL_ADDRESS        (confidence: 1.00)\n",
-      "  GPE                  → LOCATION             (confidence: 1.00)\n",
-      "  IBAN_CODE            → IBAN_CODE            (confidence: 1.00)\n",
-      "  IP_ADDRESS           → IP_ADDRESS           (confidence: 1.00)\n",
-      "  NRP                  → NRP                  (confidence: 1.00)\n",
-      "  ORGANIZATION         → None                 (confidence: 0.00)\n",
-      "  PERSON               → PERSON               (confidence: 1.00)\n",
-      "  PHONE_NUMBER         → PHONE_NUMBER         (confidence: 1.00)\n",
-      "  STREET_ADDRESS       → LOCATION             (confidence: 1.00)\n",
-      "  TITLE                → None                 (confidence: 0.00)\n",
-      "  US_DRIVER_LICENSE    → US_DRIVER_LICENSE    (confidence: 1.00)\n",
-      "  US_SSN               → US_SSN               (confidence: 1.00)\n",
-      "  ZIP_CODE             → LOCATION             (confidence: 1.00)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Inspect pending labels and their closest suggestions programmatically\n",
     "import difflib\n",
     "\n",
-    "from presidio_evaluator.entity_mapping import ALL_CANONICAL_ENTITIES\n",
+    "from presidio_evaluator.entity_mapping import EntityHierarchy\n",
+    "\n",
+    "all_canonical = EntityHierarchy().all_canonical_entities\n",
     "\n",
     "if not isinstance(mapper, dict) and mapper.pending:\n",
     "    print(\"Labels still pending:\")\n",
@@ -581,7 +580,7 @@
     "        norm = label.upper().replace(\"_\", \"\").replace(\"-\", \"\")\n",
     "        suggestions = difflib.get_close_matches(\n",
     "            norm,\n",
-    "            [c.upper().replace(\"_\", \"\") for c in ALL_CANONICAL_ENTITIES],\n",
+    "            [c.upper().replace(\"_\", \"\") for c in all_canonical],\n",
     "            n=3,\n",
     "            cutoff=0.4,\n",
     "        )\n",
@@ -606,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "ad61b472",
    "metadata": {},
    "outputs": [
@@ -614,7 +613,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "All entities are already mapped!\n"
+      "Entity mapping ready:\n",
+      "{'AGE': 'AGE',\n",
+      " 'CREDIT_CARD': 'FINANCIAL',\n",
+      " 'DATE_TIME': 'DATE_TIME',\n",
+      " 'DOMAIN_NAME': 'DOMAIN',\n",
+      " 'EMAIL_ADDRESS': 'EMAIL_ADDRESS',\n",
+      " 'GPE': 'GPE',\n",
+      " 'IBAN_CODE': 'FINANCIAL',\n",
+      " 'IP_ADDRESS': 'IP_ADDRESS',\n",
+      " 'NRP': 'NATIONALITY',\n",
+      " 'ORGANIZATION': 'ORGANIZATION',\n",
+      " 'PERSON': 'PERSON',\n",
+      " 'PHONE_NUMBER': 'PHONE_NUMBER',\n",
+      " 'STREET_ADDRESS': 'ADDRESS',\n",
+      " 'TITLE': None,\n",
+      " 'US_DRIVER_LICENSE': 'DRIVER_LICENSE',\n",
+      " 'US_SSN': 'SSN',\n",
+      " 'ZIP_CODE': 'ADDRESS'}\n"
      ]
     }
    ],
@@ -636,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "13e57a9e",
    "metadata": {},
    "outputs": [
@@ -644,27 +660,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Entity Mapping (dataset → model):\n",
-      "{'AGE': 'DATE_TIME',\n",
-      " 'CREDIT_CARD': 'CREDIT_CARD',\n",
+      "Entity mapping (17 labels):\n",
+      "{'AGE': 'AGE',\n",
+      " 'CREDIT_CARD': 'FINANCIAL',\n",
       " 'DATE_TIME': 'DATE_TIME',\n",
-      " 'DOMAIN_NAME': 'URL',\n",
+      " 'DOMAIN_NAME': 'DOMAIN',\n",
       " 'EMAIL_ADDRESS': 'EMAIL_ADDRESS',\n",
-      " 'GPE': 'LOCATION',\n",
-      " 'IBAN_CODE': 'IBAN_CODE',\n",
+      " 'GPE': 'GPE',\n",
+      " 'IBAN_CODE': 'FINANCIAL',\n",
       " 'IP_ADDRESS': 'IP_ADDRESS',\n",
-      " 'NRP': 'NRP',\n",
+      " 'NRP': 'NATIONALITY',\n",
+      " 'ORGANIZATION': 'ORGANIZATION',\n",
       " 'PERSON': 'PERSON',\n",
       " 'PHONE_NUMBER': 'PHONE_NUMBER',\n",
-      " 'STREET_ADDRESS': 'LOCATION',\n",
-      " 'US_DRIVER_LICENSE': 'US_DRIVER_LICENSE',\n",
-      " 'US_SSN': 'US_SSN',\n",
-      " 'ZIP_CODE': 'LOCATION'}\n",
+      " 'STREET_ADDRESS': 'ADDRESS',\n",
+      " 'TITLE': None,\n",
+      " 'US_DRIVER_LICENSE': 'DRIVER_LICENSE',\n",
+      " 'US_SSN': 'SSN',\n",
+      " 'ZIP_CODE': 'ADDRESS'}\n",
       "\n",
-      "Model entities to use (14):\n",
-      "['CREDIT_CARD', 'DATE_TIME', 'EMAIL_ADDRESS', 'IBAN_CODE', 'IP_ADDRESS',\n",
-      " 'LOCATION', 'NRP', 'ORGANIZATION', 'PERSON', 'PHONE_NUMBER', 'TITLE', 'URL',\n",
-      " 'US_DRIVER_LICENSE', 'US_SSN']\n"
+      "Model entities to evaluate (14):\n",
+      "['ADDRESS', 'AGE', 'DATE_TIME', 'DOMAIN', 'DRIVER_LICENSE', 'EMAIL_ADDRESS',\n",
+      " 'FINANCIAL', 'GPE', 'IP_ADDRESS', 'NATIONALITY', 'ORGANIZATION', 'PERSON',\n",
+      " 'PHONE_NUMBER', 'SSN']\n"
      ]
     }
    ],
@@ -681,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b30f0182",
    "metadata": {},
    "outputs": [
@@ -692,10 +710,10 @@
       "=== Evaluation Strategy Comparison ===\n",
       "\n",
       "Filtered strategy (entities_to_keep=14):\n",
-      "  Only these entities count: ['CREDIT_CARD', 'DATE_TIME', 'EMAIL_ADDRESS', 'IBAN_CODE', 'IP_ADDRESS', 'LOCATION', 'NRP', 'ORGANIZATION', 'PERSON', 'PHONE_NUMBER', 'TITLE', 'URL', 'US_DRIVER_LICENSE', 'US_SSN']\n",
+      "  Only these entities count: ['ADDRESS', 'AGE', 'DATE_TIME', 'DOMAIN', 'DRIVER_LICENSE', 'EMAIL_ADDRESS', 'FINANCIAL', 'GPE', 'IP_ADDRESS', 'NATIONALITY', 'ORGANIZATION', 'PERSON', 'PHONE_NUMBER', 'SSN']\n",
       "\n",
-      "  Model entities IGNORED (7):\n",
-      "  ['CRYPTO', 'MAC_ADDRESS', 'MEDICAL_LICENSE', 'UK_NHS', 'US_BANK_NUMBER', 'US_ITIN', 'US_PASSPORT']\n",
+      "  Model entities IGNORED (14):\n",
+      "  ['CREDIT_CARD', 'CRYPTO', 'IBAN_CODE', 'LOCATION', 'MAC_ADDRESS', 'MEDICAL_LICENSE', 'NRP', 'UK_NHS', 'URL', 'US_BANK_NUMBER', 'US_DRIVER_LICENSE', 'US_ITIN', 'US_PASSPORT', 'US_SSN']\n",
       "  → Predictions of these types won't count as FP or TP\n",
       "\n",
       "Full model strategy (entities_to_keep=None):\n",
@@ -725,22 +743,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "e4132a05",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:presidio_evaluator.evaluation.base_evaluator:skip words not provided, using default skip words. If you want the evaluation to not use skip words, pass skip_words=[]\n",
+      "WARNING:presidio_evaluator.evaluation.base_evaluator:skip words not provided, using default skip words. If you want the evaluation to not use skip words, pass skip_words=[]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------\n",
+      "Entities supported by this Presidio Analyzer instance:\n",
+      "UK_NHS, DATE_TIME, MEDICAL_LICENSE, US_BANK_NUMBER, US_PASSPORT, US_ITIN, US_SSN, IP_ADDRESS, IBAN_CODE, PERSON, PHONE_NUMBER, NRP, URL, LOCATION, EMAIL_ADDRESS, US_DRIVER_LICENSE, CRYPTO, CREDIT_CARD, MAC_ADDRESS\n",
+      "Ready to evaluate. Run the next cell to compare strategies.\n"
+     ]
+    }
+   ],
    "source": [
     "wrapped_analyzer = PresidioAnalyzerWrapper(analyzer_engine=analyzer, language=\"en\")\n",
     "\n",
     "# Strategy 1: Filtered entities (recommended — avoids spurious FPs)\n",
     "evaluator_filtered = SpanEvaluator(\n",
-    "    model=wrapped_analyzer,\n",
     "    entities_to_keep=list(model_entities_to_use),\n",
     ")\n",
     "\n",
     "# Strategy 2: All model entities\n",
     "evaluator_full = SpanEvaluator(\n",
-    "    model=wrapped_analyzer,\n",
     "    entities_to_keep=None,\n",
     ")\n",
     "\n",
@@ -749,26 +784,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "ae5f8d35",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<timed exec>:7: UserWarning: Some annotations and predictions resolve to different canonical entities: 'AGE' vs 'DATE_TIME', 'DOMAIN_NAME' vs 'URL', 'GPE' vs 'LOCATION', 'GPE' vs 'PERSON', 'ORGANIZATION' vs 'PERSON', 'PERSON' vs 'LOCATION', 'STREET_ADDRESS' vs 'DATE_TIME', 'STREET_ADDRESS' vs 'LOCATION', 'STREET_ADDRESS' vs 'NRP', 'STREET_ADDRESS' vs 'PERSON', 'US_DRIVER_LICENSE' vs 'PHONE_NUMBER'. This will count as false negatives/positives. To fix this: (a) call get_mapped_results_dataframe(results_df, hierarchy=2) to use a broader mapping level where both resolve to the same entity, or (b) call mapper.map({'<label>': '<canonical>'}) to manually specify the mapping.\n",
+      "<timed exec>:8: UserWarning: Some annotations and predictions resolve to different canonical entities: 'AGE' vs 'DATE_TIME', 'DOMAIN_NAME' vs 'URL', 'GPE' vs 'LOCATION', 'GPE' vs 'PERSON', 'ORGANIZATION' vs 'PERSON', 'PERSON' vs 'LOCATION', 'STREET_ADDRESS' vs 'DATE_TIME', 'STREET_ADDRESS' vs 'LOCATION', 'STREET_ADDRESS' vs 'NRP', 'STREET_ADDRESS' vs 'PERSON', 'US_DRIVER_LICENSE' vs 'PHONE_NUMBER'. This will count as false negatives/positives. To fix this: (a) call get_mapped_results_dataframe(results_df, hierarchy=2) to use a broader mapping level where both resolve to the same entity, or (b) call mapper.map({'<label>': '<canonical>'}) to manually specify the mapping.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== Strategy Comparison (100 samples) ===\n",
+      "\n",
+      "Metric                   Filtered   Full Model\n",
+      "--------------------------------------------\n",
+      "PII Precision               0.667        0.667\n",
+      "PII Recall                  0.581        0.581\n",
+      "PII F1                      0.596        0.596\n",
+      "CPU times: user 946 ms, sys: 15.7 ms, total: 961 ms\n",
+      "Wall time: 934 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "\n",
     "subset = dataset[:100]\n",
     "\n",
-    "# Step 1: Predict\n",
-    "results_df_filtered = wrapped_analyzer.predict_dataset(subset)\n",
-    "results_df_full = wrapped_analyzer.predict_dataset(subset)\n",
+    "# Step 1: Predict (only need to predict once — same model)\n",
+    "results_df = wrapped_analyzer.predict_dataset(subset)\n",
     "\n",
     "# Step 2: Map\n",
-    "mapped_filtered = mapper.get_mapped_results_dataframe(results_df_filtered)\n",
-    "mapped_full = mapper.get_mapped_results_dataframe(results_df_full)\n",
+    "mapped_filtered = mapper.get_mapped_results_dataframe(results_df.copy())\n",
+    "mapped_full = mapper.get_mapped_results_dataframe(results_df.copy())\n",
     "\n",
     "# Step 3: Score\n",
-    "scores_filtered = evaluator_filtered.calculate_score_on_df(level=\"entity\", results_df=mapped_filtered)\n",
-    "scores_full = evaluator_full.calculate_score_on_df(level=\"entity\", results_df=mapped_full)\n",
+    "scores_filtered = evaluator_filtered.calculate_score_on_df(results_df=mapped_filtered)\n",
+    "scores_full = evaluator_full.calculate_score_on_df(results_df=mapped_full)\n",
     "\n",
     "print(\"\\n=== Strategy Comparison (100 samples) ===\")\n",
     "print(f\"\\n{'Metric':<20} {'Filtered':>12} {'Full Model':>12}\")\n",
@@ -796,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "4c7bc272",
    "metadata": {},
    "outputs": [
@@ -804,10 +863,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model entities not used by dataset (7):\n",
-      "['CRYPTO', 'MAC_ADDRESS', 'MEDICAL_LICENSE', 'UK_NHS', 'US_BANK_NUMBER',\n",
-      " 'US_ITIN', 'US_PASSPORT']\n",
-      "✓ Excluded 7 model entity(ies)\n"
+      "Model entities not in dataset mapping (14):\n",
+      "['CREDIT_CARD', 'CRYPTO', 'IBAN_CODE', 'LOCATION', 'MAC_ADDRESS',\n",
+      " 'MEDICAL_LICENSE', 'NRP', 'UK_NHS', 'URL', 'US_BANK_NUMBER',\n",
+      " 'US_DRIVER_LICENSE', 'US_ITIN', 'US_PASSPORT', 'US_SSN']\n",
+      "\n",
+      "Pass `entities_to_keep=mapped_model_entities` to SpanEvaluator to ignore these.\n"
      ]
     }
    ],
@@ -855,10 +916,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "2e585409",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== CanonicalMapper Quick Reference ===\n",
+      "\n",
+      "# Collect unique entity labels from a dataset (InputSample list)\n",
+      "labels = list({tag for sample in dataset for tag in sample.tags if tag != \"O\"})\n",
+      "\n",
+      "# Build mapper from labels — auto-resolves all labels it can\n",
+      "mapper = CanonicalMapper(labels=labels)\n",
+      "# Returns a CanonicalMapper instance.\n",
+      "\n",
+      "# Inspect auto-resolution\n",
+      "mapper.render_html()          # HTML audit table (Jupyter)\n",
+      "mapper._print_text()          # Plain-text fallback\n",
+      "\n",
+      "# Check pending labels\n",
+      "mapper.pending                # list of unresolved labels\n",
+      "\n",
+      "# Assign manually\n",
+      "mapper.map({\n",
+      "    \"MY_LABEL\": \"PERSON\",     # resolve to canonical entity\n",
+      "    \"NOISE\":    None,          # suppress from evaluation\n",
+      "})\n",
+      "\n",
+      "# Interactive terminal resolution (shows ranked suggestions)\n",
+      "mapper.resolve_interactively()\n",
+      "\n",
+      "# Get the final mapping dict (raises IncompleteMapping if pending is non-empty)\n",
+      "entity_mapping = mapper.get_mapping()  # {raw_label: canonical | None}\n",
+      "\n",
+      "# New 3-step pipeline\n",
+      "results_df = model.predict_dataset(dataset)\n",
+      "mapped_df = mapper.get_mapped_results_dataframe(results_df)\n",
+      "scores = evaluator.calculate_score_on_df(level=\"entity\", results_df=mapped_df)\n",
+      "\n",
+      "# Use with SpanEvaluator (no entity_mapping parameter)\n",
+      "entities_to_keep = {v for v in entity_mapping.values() if v is not None}\n",
+      "evaluator = SpanEvaluator(\n",
+      "    model=wrapped_model,\n",
+      "    entities_to_keep=list(entities_to_keep),\n",
+      ")\n",
+      "\n",
+      "# Customize the taxonomy\n",
+      "from presidio_evaluator.entity_mapping import EntityHierarchy\n",
+      "h = EntityHierarchy()\n",
+      "h.add_alias(\"EMAIL_ADDRESS\", \"E_MAIL\")\n",
+      "mapper = CanonicalMapper(labels=labels, hierarchy=h)\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"\"\"\n",
     "=== CanonicalMapper Quick Reference ===\n",
@@ -903,16 +1018,24 @@
     "\n",
     "# Customize the taxonomy\n",
     "from presidio_evaluator.entity_mapping import EntityHierarchy\n",
-    "h = EntityHierarchy.default().copy()\n",
+    "h = EntityHierarchy()\n",
     "h.add_alias(\"EMAIL_ADDRESS\", \"E_MAIL\")\n",
     "mapper = CanonicalMapper(labels=labels, hierarchy=h)\n",
     "\"\"\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0825464f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "presidio",
    "language": "python",
    "name": "python3"
   },
@@ -926,7 +1049,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.9"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-include = ["presidio_evaluator/data_generator/raw_data/*"]
+artifacts = ["presidio_evaluator/data_generator/raw_data/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["."]


### PR DESCRIPTION
This pull request makes a minor configuration update to the `pyproject.toml` file, changing the wheel build target option from `include` to `artifacts` for specifying files to include in the build. 


### Changes summary

**Notebook 5** (`5_Evaluate_Custom_Presidio_Analyzer.ipynb`) — changed `ModelError.get_fps_dataframe(..., entity="AGE")`  to `ModelError.get_fps_dataframe(..., entity="LOCATION")` (an entity that has FPs) so fps_df will not return as None.

**Notebook 6** (6_Interactive_Entity_Mapping.ipynb) — Four cells were fixed:

| Cell | Issue | Fix |
|------|-------|-----|
| 16 | `EntityHierarchy.default().copy()` — class has no `default()` or `copy()` methods | Changed to `EntityHierarchy()` (constructor already deep-copies the default hierarchy) |
| 19 | `from presidio_evaluator.entity_mapping import ALL_CANONICAL_ENTITIES` — no such module-level export | Changed to `EntityHierarchy().all_canonical_entities` (instance attribute) |
| 24 | `SpanEvaluator(model=wrapped_analyzer, ...)` — passing `model` to constructor raises `DeprecationError` | Removed `model=` from both `SpanEvaluator()` calls |
| 25 | Predicted twice unnecessarily; used `level="entity"` but printed `pii_precision`/`pii_recall`/`pii_f` (only populated with `level="both"`) | Predict once, switched to default `level="both"` |
| 29 (quick ref) | Same stale `EntityHierarchy.default().copy()` pattern | Changed to `EntityHierarchy()` |