### PR TITLE
ci: add PyPI trusted-publishing release workflow (v0.3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish to PyPI
+
+# Publishes presidio-evaluator to PyPI when a GitHub Release is published.
+# Uses PyPI Trusted Publishing (OIDC) — no API tokens are stored.
+#
+# One-time PyPI setup (by a project owner of `presidio-evaluator`):
+#   PyPI project -> Settings -> Publishing -> Add a trusted publisher (GitHub Actions):
+#     Owner:            data-privacy-stack
+#     Repository:       presidio-research
+#     Workflow name:    publish.yml
+#     Environment:      pypi
+#
+# To release: bump `version` in pyproject.toml, then publish a GitHub Release
+# whose tag matches (e.g. tag `0.3`).
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for trusted publishing (OIDC)
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ on:
   release:
     types: [published]
 
+# Least-privilege default for all jobs; the publish job widens this for OIDC.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distributions
@@ -42,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write  # required for trusted publishing (OIDC)
     steps:
       - name: Download build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history needed to check the tag is on main
+
+      - name: Verify release tag matches pyproject version
+        run: |
+          set -euo pipefail
+          version=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Release tag '$GITHUB_REF_NAME' does not match pyproject version '$version'."
+            exit 1
+          fi
+          echo "Release tag matches pyproject version ($version)."
+
+      - name: Verify release commit is contained in main
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Release commit $GITHUB_SHA is not contained in main; refusing to publish."
+            exit 1
+          fi
+          echo "Release commit is contained in main."
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## Version 0.3
 
 > **Migration guide:** See [docs/migration-guide.md](docs/migration-guide.md) for step-by-step upgrade instructions.
 
@@ -32,6 +32,10 @@
 ### Deprecations
 
 - **`evaluator.get_results_dataframe()`** — soft `DeprecationWarning` emitted at runtime. Replace with `model.predict_dataset(dataset)`.
+
+### CI/CD
+
+- **PyPI release workflow** — added `.github/workflows/publish.yml`, which builds and publishes the package to PyPI via Trusted Publishing (OIDC) when a GitHub Release is published. Replaces the retired Azure DevOps `publish-to-pypi` pipeline.
 
 
 


### PR DESCRIPTION
## Summary

Adds an automated PyPI release path for the new `data-privacy-stack` org and prepares the CHANGELOG for **0.3**.

- **`.github/workflows/publish.yml`** — builds the package with `uv` and publishes to PyPI via **Trusted Publishing (OIDC)** when a GitHub Release is published. Split into `build` + `publish` jobs so only the publish job holds `id-token: write` (least privilege), gated behind the `pypi` environment.
- **CHANGELOG** — promotes the `Unreleased` section to **Version 0.3** and documents the new release workflow. Replaces the retired Azure DevOps `publish-to-pypi` pipeline.

Verified `uv build` produces a clean `presidio_evaluator-0.3` sdist + wheel locally.

## Required one-time PyPI setup (before first release)

A current **owner** of the `presidio-evaluator` PyPI project must register this repo as a trusted publisher:

> PyPI project → *Publishing* → *Add a trusted publisher (GitHub Actions)*
> - Owner: `data-privacy-stack` · Repo: `presidio-research` · Workflow: `publish.yml` · Environment: `pypi`

The workflow file must be on the **default branch** for the match to succeed.

## How to release after merge

1. Confirm `version` in `pyproject.toml` (currently `0.3`).
2. Create a GitHub Release with tag `0.3` → workflow builds and publishes automatically.

## Note
`authors` in `pyproject.toml` still reads `Microsoft`; consider updating for the new org in a follow-up.