### PR TITLE
chore: remove Microsoft-specific branding and governance docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,12 @@
 ## Version 0.2.5
 
 ### Improvements
- - Introduced a new evaluator, `SpanEvaluator` which compares full spans of annotations and predictions, instead of tokens. ([#141](https://github.com/microsoft/presidio-research/pull/141))
- - Make Azure SDK as an optional dependency ([#116](https://github.com/microsoft/presidio-research/pull/116))
- - Add a DF output to evaluation results ([#126](https://github.com/microsoft/presidio-research/pull/126))
+ - Introduced a new evaluator, `SpanEvaluator` which compares full spans of annotations and predictions, instead of tokens. ([#141](https://github.com/data-privacy-stack/presidio-research/pull/141))
+ - Make Azure SDK as an optional dependency ([#116](https://github.com/data-privacy-stack/presidio-research/pull/116))
+ - Add a DF output to evaluation results ([#126](https://github.com/data-privacy-stack/presidio-research/pull/126))
 ### Bug Fixes
- - Fixed bugs around plotting and experiment tracking (#140) around configuring Presidio in the evaluation loop. ([#155](https://github.com/microsoft/presidio-research/pull/155))
- - Data generation bug fixes [#113](https://github.com/microsoft/presidio-research/pull/113)
+ - Fixed bugs around plotting and experiment tracking (#140) around configuring Presidio in the evaluation loop. ([#155](https://github.com/data-privacy-stack/presidio-research/pull/155))
+ - Data generation bug fixes [#113](https://github.com/data-privacy-stack/presidio-research/pull/113)
 
 ## Version 0.2.0
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,83 @@
-# Microsoft Open Source Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+## Our Pledge
 
-Resources:
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
-- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at presidio@dataprivacystack.org. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0, available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
+This project incorporates components from the projects listed below. The original copyright notices and the licenses under which such components were received are set forth below. All rights not expressly granted herein are reserved, whether by implication, estoppel or otherwise.
 
 
 *******

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Presidio-research
 
 This package provides evaluation and data-science capabilities for
-[Presidio](https://github.com/microsoft/presidio) and PII detection models in general.
+[Presidio](https://github.com/data-privacy-stack/presidio) and PII detection models in general.
 
 It also includes a fake data generator that creates synthetic sentences based on templates and fake PII.
 
@@ -135,17 +135,12 @@ The presidio-evaluator framework allows you to evaluate Presidio as a system, a 
 
 # Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
+This project welcomes contributions and suggestions. Open an issue to discuss larger changes
+before submitting a pull request.
 
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable behavior
+to <presidio@dataprivacystack.org>.
 
 Copyright notice:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,22 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.3 BLOCK -->
+# Security Policy
 
-## Security
+We take the security of this project seriously. If you believe you have found a security vulnerability, please report it to us responsibly using the instructions below.
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+## Reporting a Vulnerability
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)) of a security vulnerability, please report it to us as described below.
+**Please do not open public GitHub issues for security vulnerabilities.**
 
-## Reporting Security Issues
+Instead, please use GitHub's **Private Vulnerability Reporting** feature:
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+1. Navigate to the main page of the repository.
+2. Under the repository name, click **Security**.
+3. In the left sidebar, click **Reporting**.
+4. Click **Report a vulnerability** to open the advisory form.
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+Alternatively, you can use this direct link: [Report a Security Vulnerability](https://github.com/data-privacy-stack/presidio-research/security/advisories/new)
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+## Our Process
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
-
-## Preferred Languages
-
-We prefer all communications to be in English.
-
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+* **Acknowledgment:** We will acknowledge receipt of your report within 48 hours.
+* **Evaluation:** We will investigate the issue and keep you updated via the private GitHub Advisory thread.
+* **Disclosure:** Once a fix is ready, we will coordinate the release and publish a Security Advisory to credit your work (if desired).

--- a/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
+++ b/notebooks/5_Evaluate_Custom_Presidio_Analyzer.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## Evaluate a custom Presidio Analyzer using the Presidio Evaluator framework\n",
     "\n",
-    "This notebook demonstrates how to evaluate a Presidio instance using the presidio-evaluator framework. It builds upon [notebook 4](4_Evaluate_Presidio_Analyzer.ipynb), customising the `PresidioAnalyzer` instance for better accuracy. For more on customising Presidio, see the [Presidio Analyzer documentation](https://microsoft.github.io/presidio/analyzer/).\n",
+    "This notebook demonstrates how to evaluate a Presidio instance using the presidio-evaluator framework. It builds upon [notebook 4](4_Evaluate_Presidio_Analyzer.ipynb), customising the `PresidioAnalyzer` instance for better accuracy. For more on customising Presidio, see the [Presidio Analyzer documentation](https://presidio.dataprivacystack.org/analyzer/).\n",
     "\n",
     "Steps:\n",
     "1. Load dataset\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11,<3.14"
 authors = [
-    {name = "Microsoft"}
+    {name = "Presidio contributors"}
 ]
 dependencies = [
     "spacy>=3.8.0",


### PR DESCRIPTION
> [!NOTE]
> Stacked on #177 (both touch notebook 5). Base will need retargeting to `main` once #177 merges.

## Summary

The project has moved out of the Microsoft org, so this replaces the Microsoft-specific governance material with the same setup used in `data-privacy-stack/presidio`.

- **CODE_OF_CONDUCT.md** — Microsoft OSS CoC → Contributor Covenant (copied verbatim from `data-privacy-stack/presidio`)
- **SECURITY.md** — MSRC reporting block → GitHub private vulnerability reporting, pointed at this repo's advisory form
- **README** — dropped the Microsoft CLA paragraph (no CLA bot on the new org); CoC section now points at the Contributor Covenant
- **pyproject.toml** — author `Microsoft` → `Presidio contributors`, matching the LICENSE copyright line
- **NOTICE** — neutral third-party attribution preamble
- **Links** — `microsoft/presidio` → `data-privacy-stack/presidio` and `microsoft.github.io/presidio` → `presidio.dataprivacystack.org` in README, CHANGELOG and notebook 5 (the upstream project moved orgs too; both new URLs verified 200)

## Deliberately left alone

- `NOTICE:766` — `Copyright (c) Microsoft Corporation` is the actual upstream Presidio MIT notice
- `entity_mapping/definitions.py` — `"MS"` is the ISO country code for Montserrat
- Test fixtures and `companies_and_organizations.csv` — `"Microsoft"` there is sample ORGANIZATION text alongside `"Apple"` and `"Google"`, not branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)