### PR TITLE
Fix token-based span IoU to be position-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### Bug Fixes
+
+- **Token-based span IoU is now position-aware** — `SpanEvaluator` with `char_based=False` previously compared sets of token strings, so identical words at different positions were wrongly treated as overlapping (e.g. annotating the first "Michael" in "Michael met Michael" while predicting the second counted as a true positive, and "Human Rights" vs "Civil Rights" had a non-zero IoU through the shared word "Rights"). Token-level IoU now compares `(position, token)` pairs; `Span` gained an optional `normalized_start_indices` field to support this. Spans built without per-token indices fall back to string comparison guarded by a positional-overlap check.
+
 ## Version 0.3
 
 > **Migration guide:** See [docs/migration-guide.md](docs/migration-guide.md) for step-by-step upgrade instructions.

--- a/presidio_evaluator/data_objects.py
+++ b/presidio_evaluator/data_objects.py
@@ -51,6 +51,8 @@ class Span:
     :param normalized_tokens: Optional list of normalized tokens (excluding skip words, punctuation etc.)
     :param normalized_start_index: Optional start index of the normalized value in the text
     :param normalized_end_index: Optional end index of the normalized value in the text
+    :param normalized_start_indices: Optional per-token start indices of the normalized tokens,
+        used for position-aware token-level comparisons
     """
 
     def __init__(
@@ -64,6 +66,7 @@ class Span:
         normalized_tokens: list[str] | None = None,
         normalized_start_index: int | None = None,
         normalized_end_index: int | None = None,
+        normalized_start_indices: list[int] | None = None,
     ) -> None:
         self.entity_type = entity_type
         self.entity_value = entity_value
@@ -72,6 +75,7 @@ class Span:
         self.normalized_tokens = normalized_tokens
         self.normalized_start_index = normalized_start_index
         self.normalized_end_index = normalized_end_index
+        self.normalized_start_indices = normalized_start_indices
         self.token_start = token_start
         self.token_end = token_end
 

--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -228,7 +228,7 @@ class SpanEvaluator(BaseEvaluator):
             carry per-token start indices
         """
         tokens = span.normalized_tokens or []
-        indices = getattr(span, "normalized_start_indices", None)
+        indices = span.normalized_start_indices
         if indices is None or len(indices) != len(tokens):
             return None
         return set(zip(indices, tokens, strict=True))
@@ -599,7 +599,7 @@ class SpanEvaluator(BaseEvaluator):
                                 token_start=current_token_start,
                                 current_tokens=current_tokens,
                                 idx=idx,
-                                normalized_satrt_indices=normalized_start_indices,
+                                normalized_start_indices=normalized_start_indices,
                                 normalized_tokens=normalized_tokens,
                             ),
                         )
@@ -625,7 +625,7 @@ class SpanEvaluator(BaseEvaluator):
                                 token_start=current_token_start,
                                 current_tokens=current_tokens,
                                 idx=idx,
-                                normalized_satrt_indices=normalized_start_indices,
+                                normalized_start_indices=normalized_start_indices,
                                 normalized_tokens=normalized_tokens,
                             ),
                         )
@@ -654,7 +654,7 @@ class SpanEvaluator(BaseEvaluator):
                         token_start=current_token_start,
                         current_tokens=current_tokens,
                         idx=df.index[-1] + 1,
-                        normalized_satrt_indices=normalized_start_indices,
+                        normalized_start_indices=normalized_start_indices,
                         normalized_tokens=normalized_tokens,
                     ),
                 )
@@ -667,7 +667,7 @@ class SpanEvaluator(BaseEvaluator):
         token_start: int,
         current_tokens: list[str],
         idx: int,
-        normalized_satrt_indices: list[int],
+        normalized_start_indices: list[int],
         normalized_tokens: list[str],
     ):
         return Span(
@@ -676,12 +676,12 @@ class SpanEvaluator(BaseEvaluator):
             start_position=start_indices[0],
             end_position=start_indices[-1] + len(current_tokens[-1]),
             normalized_tokens=normalized_tokens,
-            normalized_start_index=min(normalized_satrt_indices),
+            normalized_start_index=min(normalized_start_indices),
             normalized_end_index=self._get_normalized_end_index(
                 normalized_tokens,
-                normalized_satrt_indices,
+                normalized_start_indices,
             ),
-            normalized_start_indices=normalized_satrt_indices,
+            normalized_start_indices=normalized_start_indices,
             token_start=token_start,
             token_end=idx,
         )

--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -206,6 +206,13 @@ class SpanEvaluator(BaseEvaluator):
         ignoring prediction spans with no positional overlap so that identical
         words at disjoint positions can't match.
 
+        Known limitation of the fallback path: once spans do overlap
+        positionally, token strings can't be disambiguated without positions,
+        so a repeated word may over-count the intersection (e.g. annotation
+        "Michael Smith" vs prediction "Smith met Michael" yields 1.0 instead
+        of 1/3). Spans built by _create_spans always carry per-token indices
+        and take the exact position-aware path.
+
         :param ann_span: The annotation Span to match against
         :param pred_spans: One or more prediction Spans; their tokens are pooled
             before computing the IoU
@@ -252,11 +259,18 @@ class SpanEvaluator(BaseEvaluator):
         :param span: Span to extract positional tokens from
         :return: Set of (start index, token) pairs, or None if the span does not
             carry per-token start indices
+        :raises ValueError: If the span carries per-token start indices whose
+            length does not match the number of normalized tokens
         """
         tokens = span.normalized_tokens or []
         indices = span.normalized_start_indices
-        if indices is None or len(indices) != len(tokens):
+        if indices is None:
             return None
+        if len(indices) != len(tokens):
+            raise ValueError(
+                f"Inconsistent Span: {len(tokens)} normalized tokens but "
+                f"{len(indices)} normalized start indices ({span})",
+            )
         return set(zip(indices, tokens, strict=True))
 
     def _process_sentence_spans(

--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -110,6 +110,16 @@ class SpanEvaluator(BaseEvaluator):
                 merged_normalized_text = (current.normalized_tokens or []) + (
                     next_span.normalized_tokens or []
                 )
+                if (
+                    current.normalized_start_indices is not None
+                    and next_span.normalized_start_indices is not None
+                ):
+                    merged_normalized_indices = (
+                        current.normalized_start_indices
+                        + next_span.normalized_start_indices
+                    )
+                else:
+                    merged_normalized_indices = None
                 current = Span(
                     entity_type=current.entity_type,
                     entity_value=" ".join(merged_tokens),
@@ -124,6 +134,7 @@ class SpanEvaluator(BaseEvaluator):
                         next_span.normalized_end_index or 0,
                     ),
                     normalized_tokens=merged_normalized_text,
+                    normalized_start_indices=merged_normalized_indices,
                     token_start=current.token_start,
                     token_end=next_span.token_end,
                 )
@@ -178,8 +189,23 @@ class SpanEvaluator(BaseEvaluator):
                 use_normalized_indices=use_normalized_indices,
             )
         else:
-            range1 = set(span1.normalized_tokens or [])
-            range2 = set(span2.normalized_tokens or [])
+            range1 = SpanEvaluator._positional_tokens(span1)
+            range2 = SpanEvaluator._positional_tokens(span2)
+
+            if range1 is None or range2 is None:
+                # Spans without per-token indices: identical token strings at
+                # different positions must not match, so require positional overlap.
+                if (
+                    span1.intersect(
+                        span2,
+                        ignore_entity_type=ignore_entity_type,
+                        use_normalized_indices=use_normalized_indices,
+                    )
+                    == 0
+                ):
+                    return 0.0
+                range1 = set(span1.normalized_tokens or [])
+                range2 = set(span2.normalized_tokens or [])
 
             intersection = len(range1.intersection(range2))
             union = len(range1.union(range2))
@@ -187,6 +213,25 @@ class SpanEvaluator(BaseEvaluator):
             iou = intersection / union if union > 0 else 0.0
 
         return iou
+
+    @staticmethod
+    def _positional_tokens(span: Span) -> set[tuple[int, str]] | None:
+        """
+        Build a position-aware token set of (start index, token) pairs for a span.
+
+        Comparing tokens together with their positions prevents identical words at
+        different positions (e.g. both occurrences in "Michael met Michael") from
+        being treated as the same token.
+
+        :param span: Span to extract positional tokens from
+        :return: Set of (start index, token) pairs, or None if the span does not
+            carry per-token start indices
+        """
+        tokens = span.normalized_tokens or []
+        indices = getattr(span, "normalized_start_indices", None)
+        if indices is None or len(indices) != len(tokens):
+            return None
+        return set(zip(indices, tokens, strict=True))
 
     def _process_sentence_spans(
         self,
@@ -636,6 +681,7 @@ class SpanEvaluator(BaseEvaluator):
                 normalized_tokens,
                 normalized_satrt_indices,
             ),
+            normalized_start_indices=normalized_satrt_indices,
             token_start=token_start,
             token_end=idx,
         )
@@ -1261,11 +1307,33 @@ class SpanEvaluator(BaseEvaluator):
             intersection = len(ann_chars.intersection(pred_chars))
             union = len(ann_chars.union(pred_chars))
         else:
-            # Token-based IoU
-            ann_tokens = set(annotation_span.normalized_tokens or [])
-            pred_tokens: set[str] = set()
-            for pred_span in prediction_spans:
-                pred_tokens.update(pred_span.normalized_tokens or [])
+            # Token-based IoU, position-aware when per-token indices are available
+            ann_tokens = self._positional_tokens(annotation_span)
+            pred_spans_with_tokens = [
+                (pred_span, self._positional_tokens(pred_span))
+                for pred_span in prediction_spans
+            ]
+            if ann_tokens is not None and all(
+                tokens is not None for _, tokens in pred_spans_with_tokens
+            ):
+                pred_tokens: set = set()
+                for _, tokens in pred_spans_with_tokens:
+                    pred_tokens.update(tokens or set())
+            else:
+                # Fallback for spans without per-token indices: compare token
+                # strings, ignoring predictions with no positional overlap.
+                ann_tokens = set(annotation_span.normalized_tokens or [])
+                pred_tokens = set()
+                for pred_span in prediction_spans:
+                    if (
+                        pred_span.intersect(
+                            annotation_span,
+                            ignore_entity_type=True,
+                            use_normalized_indices=True,
+                        )
+                        > 0
+                    ):
+                        pred_tokens.update(pred_span.normalized_tokens or [])
 
             intersection = len(ann_tokens.intersection(pred_tokens))
             union = len(ann_tokens.union(pred_tokens))

--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -189,30 +189,56 @@ class SpanEvaluator(BaseEvaluator):
                 use_normalized_indices=use_normalized_indices,
             )
         else:
-            range1 = SpanEvaluator._positional_tokens(span1)
-            range2 = SpanEvaluator._positional_tokens(span2)
-
-            if range1 is None or range2 is None:
-                # Spans without per-token indices: identical token strings at
-                # different positions must not match, so require positional overlap.
-                if (
-                    span1.intersect(
-                        span2,
-                        ignore_entity_type=ignore_entity_type,
-                        use_normalized_indices=use_normalized_indices,
-                    )
-                    == 0
-                ):
-                    return 0.0
-                range1 = set(span1.normalized_tokens or [])
-                range2 = set(span2.normalized_tokens or [])
-
-            intersection = len(range1.intersection(range2))
-            union = len(range1.union(range2))
-
-            iou = intersection / union if union > 0 else 0.0
+            iou = SpanEvaluator._token_iou(span1, [span2])
 
         return iou
+
+    @staticmethod
+    def _token_iou(ann_span: Span, pred_spans: list[Span]) -> float:
+        """
+        Calculate the token-level IoU between an annotation span and one or more
+        prediction spans.
+
+        When every span carries per-token start indices, tokens are compared as
+        (start index, token) pairs, so identical words at different positions
+        (e.g. both occurrences in "Michael met Michael") are distinct tokens.
+        Spans without per-token indices fall back to comparing token strings,
+        ignoring prediction spans with no positional overlap so that identical
+        words at disjoint positions can't match.
+
+        :param ann_span: The annotation Span to match against
+        :param pred_spans: One or more prediction Spans; their tokens are pooled
+            before computing the IoU
+        :return: IoU value between 0 and 1
+        """
+        ann_tokens = SpanEvaluator._positional_tokens(ann_span)
+        pred_token_sets = [
+            SpanEvaluator._positional_tokens(pred_span) for pred_span in pred_spans
+        ]
+
+        if ann_tokens is not None and all(
+            tokens is not None for tokens in pred_token_sets
+        ):
+            pred_tokens: set = set()
+            for tokens in pred_token_sets:
+                pred_tokens.update(tokens or set())
+        else:
+            ann_tokens = set(ann_span.normalized_tokens or [])
+            pred_tokens = set()
+            for pred_span in pred_spans:
+                if (
+                    pred_span.intersect(
+                        ann_span,
+                        ignore_entity_type=True,
+                        use_normalized_indices=True,
+                    )
+                    > 0
+                ):
+                    pred_tokens.update(pred_span.normalized_tokens or [])
+
+        intersection = len(ann_tokens.intersection(pred_tokens))
+        union = len(ann_tokens.union(pred_tokens))
+        return intersection / union if union > 0 else 0.0
 
     @staticmethod
     def _positional_tokens(span: Span) -> set[tuple[int, str]] | None:
@@ -1306,35 +1332,6 @@ class SpanEvaluator(BaseEvaluator):
                     )
             intersection = len(ann_chars.intersection(pred_chars))
             union = len(ann_chars.union(pred_chars))
-        else:
-            # Token-based IoU, position-aware when per-token indices are available
-            ann_tokens = self._positional_tokens(annotation_span)
-            pred_spans_with_tokens = [
-                (pred_span, self._positional_tokens(pred_span))
-                for pred_span in prediction_spans
-            ]
-            if ann_tokens is not None and all(
-                tokens is not None for _, tokens in pred_spans_with_tokens
-            ):
-                pred_tokens: set = set()
-                for _, tokens in pred_spans_with_tokens:
-                    pred_tokens.update(tokens or set())
-            else:
-                # Fallback for spans without per-token indices: compare token
-                # strings, ignoring predictions with no positional overlap.
-                ann_tokens = set(annotation_span.normalized_tokens or [])
-                pred_tokens = set()
-                for pred_span in prediction_spans:
-                    if (
-                        pred_span.intersect(
-                            annotation_span,
-                            ignore_entity_type=True,
-                            use_normalized_indices=True,
-                        )
-                        > 0
-                    ):
-                        pred_tokens.update(pred_span.normalized_tokens or [])
+            return intersection / union if union > 0 else 0.0
 
-            intersection = len(ann_tokens.intersection(pred_tokens))
-            union = len(ann_tokens.union(pred_tokens))
-        return intersection / union if union > 0 else 0.0
+        return self._token_iou(annotation_span, prediction_spans)

--- a/tests/evaluation/test_span_evaluator.py
+++ b/tests/evaluation/test_span_evaluator.py
@@ -1694,3 +1694,49 @@ def test_token_iou_manual_spans_disjoint_positions():
     assert iou == 0.0, (
         f"Identical words at disjoint positions must have IoU 0, got {iou}"
     )
+
+
+def test_combined_token_iou_positive_full_coverage(token_based_evaluator):
+    """Two same-type predictions that together exactly cover the annotation give combined IoU 1.0."""
+    df = pd.DataFrame(
+        {
+            "sentence_id": [0, 0, 0],
+            "token": ["New", "York", "Mets"],
+            "annotation": ["ORGANIZATION"] * 3,
+            "pred_a": ["ORGANIZATION", "O", "O"],
+            "pred_b": ["O", "ORGANIZATION", "ORGANIZATION"],
+            "start_indices": [0, 4, 9],
+        }
+    )
+    ann_span = token_based_evaluator._create_spans(df, column="annotation")[0]
+    pred_1 = token_based_evaluator._create_spans(df, column="pred_a")[0]
+    pred_2 = token_based_evaluator._create_spans(df, column="pred_b")[0]
+
+    # Spans built from the DataFrame carry per-token indices (position-aware path)
+    assert ann_span.normalized_start_indices is not None
+    assert pred_1.normalized_start_indices is not None
+    assert pred_2.normalized_start_indices is not None
+
+    combined_iou = token_based_evaluator._calculate_combined_iou(
+        ann_span, [pred_1, pred_2]
+    )
+    assert combined_iou == 1.0, (
+        f"Predictions fully covering the annotation should give combined IoU 1.0, "
+        f"got {combined_iou}"
+    )
+
+
+def test_positional_tokens_length_mismatch_raises():
+    """A Span with mismatched token/index list lengths is inconsistent and must raise."""
+    span = Span(
+        entity_type="PERSON",
+        entity_value="John Smith",
+        start_position=0,
+        end_position=10,
+        normalized_tokens=["john", "smith"],
+        normalized_start_index=0,
+        normalized_end_index=10,
+        normalized_start_indices=[0],
+    )
+    with pytest.raises(ValueError, match="normalized"):
+        SpanEvaluator._positional_tokens(span)

--- a/tests/evaluation/test_span_evaluator.py
+++ b/tests/evaluation/test_span_evaluator.py
@@ -1535,3 +1535,162 @@ def test_model_error_start_end_positions(
         assert error.end == expected["end"], (
             f"In {scenario}, {expected['error_type']} end expected {expected['end']}, got {error.end}"
         )
+
+
+# Position-aware token-based IoU:
+# token-level IoU must compare token positions, not just token strings.
+# Otherwise identical words at different positions in the sentence
+# (e.g. "Michael met Michael") wrongly count as a match.
+
+
+@pytest.fixture
+def token_based_evaluator():
+    """SpanEvaluator configured for token-based IoU without skip words."""
+    return SpanEvaluator(
+        model=None, iou_threshold=0.75, char_based=False, skip_words=[]
+    )
+
+
+def test_token_iou_same_word_different_position_is_zero(token_based_evaluator):
+    """'Michael met Michael': annotating the first and predicting the second is not a match."""
+    df = pd.DataFrame(
+        {
+            "sentence_id": [0, 0, 0, 0],
+            "token": ["Michael", "met", "Michael", "yesterday"],
+            "annotation": ["PERSON", "O", "O", "O"],
+            "prediction": ["O", "O", "PERSON", "O"],
+            "start_indices": [0, 8, 12, 20],
+        }
+    )
+
+    result = token_based_evaluator.calculate_score_on_df(results_df=df, level="entity")
+
+    person_metrics = result.per_type["PERSON"]
+    assert person_metrics.true_positives == 0, (
+        "Predicting a different occurrence of the same word must not be a TP"
+    )
+    assert person_metrics.false_negatives == 1
+    assert person_metrics.false_positives == 1
+
+
+def test_token_iou_shared_word_entities_do_not_overlap(token_based_evaluator):
+    """'Human Rights beat Civil Rights': gold and prediction share the word 'Rights' but do not overlap."""
+    tokens = ["Human", "Rights", "beat", "Civil", "Rights"]
+    start_indices = [0, 6, 13, 18, 24]
+    df = pd.DataFrame(
+        {
+            "sentence_id": [0] * len(tokens),
+            "token": tokens,
+            "annotation": ["ORGANIZATION", "ORGANIZATION", "O", "O", "O"],
+            "prediction": ["O", "O", "O", "ORGANIZATION", "ORGANIZATION"],
+            "start_indices": start_indices,
+        }
+    )
+
+    ann_spans, pred_spans = token_based_evaluator._process_sentence_spans(df)
+    iou = token_based_evaluator.calculate_iou(
+        ann_spans[0], pred_spans[0], char_based=False
+    )
+    assert iou == 0.0, (
+        f"Disjoint spans sharing the token 'rights' must have IoU 0, got {iou}"
+    )
+
+    result = token_based_evaluator.calculate_score_on_df(results_df=df, level="entity")
+    org_metrics = result.per_type["ORGANIZATION"]
+    assert org_metrics.true_positives == 0
+    assert org_metrics.false_negatives == 1
+    assert org_metrics.false_positives == 1
+
+
+def test_token_iou_duplicate_tokens_within_span(token_based_evaluator):
+    """Annotation 'Michael Michael' vs prediction of only the first 'Michael' is a partial match."""
+    df = pd.DataFrame(
+        {
+            "sentence_id": [0, 0],
+            "token": ["Michael", "Michael"],
+            "annotation": ["PERSON", "PERSON"],
+            "prediction": ["PERSON", "O"],
+            "start_indices": [0, 8],
+        }
+    )
+
+    ann_spans, pred_spans = token_based_evaluator._process_sentence_spans(df)
+    iou = token_based_evaluator.calculate_iou(
+        ann_spans[0], pred_spans[0], char_based=False
+    )
+    assert iou == pytest.approx(0.5), (
+        f"Predicting one of two identical tokens should give IoU 0.5, got {iou}"
+    )
+
+
+def test_token_iou_exact_match_still_one(token_based_evaluator):
+    """Sanity: identical annotation and prediction spans still yield IoU 1.0 and a TP."""
+    df = pd.DataFrame(
+        {
+            "sentence_id": [0, 0, 0],
+            "token": ["Michael", "met", "Sarah"],
+            "annotation": ["PERSON", "O", "O"],
+            "prediction": ["PERSON", "O", "O"],
+            "start_indices": [0, 8, 12],
+        }
+    )
+
+    ann_spans, pred_spans = token_based_evaluator._process_sentence_spans(df)
+    iou = token_based_evaluator.calculate_iou(
+        ann_spans[0], pred_spans[0], char_based=False
+    )
+    assert iou == 1.0
+
+    result = token_based_evaluator.calculate_score_on_df(results_df=df, level="entity")
+    assert result.per_type["PERSON"].true_positives == 1
+
+
+def test_combined_token_iou_duplicate_tokens(token_based_evaluator):
+    """Combined IoU over multiple predictions must not collapse duplicate tokens."""
+    # Annotation covers only the first "Michael"; predictions cover both occurrences.
+    df = pd.DataFrame(
+        {
+            "sentence_id": [0, 0, 0],
+            "token": ["Michael", "met", "Michael"],
+            "annotation": ["PERSON", "O", "O"],
+            "prediction": ["PERSON", "O", "LOCATION"],
+            "start_indices": [0, 8, 12],
+        }
+    )
+    ann_spans, pred_spans = token_based_evaluator._process_sentence_spans(df)
+    assert len(pred_spans) == 2
+
+    combined_iou = token_based_evaluator._calculate_combined_iou(
+        ann_spans[0], pred_spans
+    )
+    assert combined_iou == pytest.approx(0.5), (
+        "One matching token out of two predicted occurrences should give combined "
+        f"IoU 0.5, got {combined_iou}"
+    )
+
+
+def test_token_iou_manual_spans_disjoint_positions():
+    """Spans built without per-token indices still respect positions via char offsets."""
+    span_first = Span(
+        entity_type="PERSON",
+        entity_value="Michael",
+        start_position=0,
+        end_position=7,
+        normalized_tokens=["michael"],
+        normalized_start_index=0,
+        normalized_end_index=7,
+    )
+    span_second = Span(
+        entity_type="PERSON",
+        entity_value="Michael",
+        start_position=12,
+        end_position=19,
+        normalized_tokens=["michael"],
+        normalized_start_index=12,
+        normalized_end_index=19,
+    )
+
+    iou = SpanEvaluator.calculate_iou(span_first, span_second, char_based=False)
+    assert iou == 0.0, (
+        f"Identical words at disjoint positions must have IoU 0, got {iou}"
+    )


### PR DESCRIPTION
## Problem

`SpanEvaluator.calculate_iou` with `char_based=False` (and the token path of `_calculate_combined_iou`) compared **sets of token strings**, discarding token positions. Two failure modes:

1. **Duplicate words**: in `"Michael met Michael"`, annotating the first *Michael* while predicting the second gave IoU = 1.0 and was counted as a true positive.
2. **Shared words across different entities**: gold `"Human Rights"` vs prediction `"Civil Rights"` produced IoU = 1/3 through the shared token *rights*, despite the spans being disjoint.

## Fix

- `Span` gains an optional `normalized_start_indices` field (per-token start indices of the normalized tokens), populated by `SpanEvaluator._create_spans` and preserved by `_merge_adjacent_spans`.
- Token-level IoU (both `calculate_iou` and `_calculate_combined_iou`) now compares sets of `(start_index, token)` pairs, making it position-aware and duplicate-safe.
- Spans constructed without per-token indices (e.g. manually built ones) fall back to the previous string comparison, but guarded by a positional-overlap check so disjoint spans always get IoU = 0.

## Tests (TDD)

Added tests written first to reproduce the bug, then made green:

- `test_token_iou_same_word_different_position_is_zero` — "Michael met Michael" end-to-end: FN + FP, not TP.
- `test_token_iou_shared_word_entities_do_not_overlap` — "Human Rights" vs "Civil Rights" IoU = 0.
- `test_token_iou_duplicate_tokens_within_span` — "Michael Michael" vs first "Michael" gives IoU 0.5, not 1.0.
- `test_token_iou_exact_match_still_one` — sanity: exact match still IoU 1.0 / TP.
- `test_combined_token_iou_duplicate_tokens` — combined IoU doesn't collapse duplicates.
- `test_token_iou_manual_spans_disjoint_positions` — fallback path for spans without per-token indices.

Full suite: 669 passed (integration tests excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)