### PR TITLE
Fix index-sensitive span merging in SpanEvaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## Version 0.3.2
+
+### Bug Fixes
+
+- **Span merging no longer depends on the DataFrame index** — `SpanEvaluator` mixed sentence-relative token positions with DataFrame index labels when checking whether two same-type spans are adjacent. With the global index produced by `predict_dataset()`, the between-tokens lookup read the wrong rows — or none at all — for every sentence except the one starting at row 0, and an empty lookup counts as "adjacent", silently merging same-type spans separated by regular words (e.g. the two PERSON spans in "John visited Berlin with Mary" became one). Span counts (`num_annotated`, `num_predicted`, `true_positives`) were deflated symmetrically for gold and predictions, so headline precision/recall could still look plausible. The evaluator now uses sentence-relative positions throughout and produces identical results for any DataFrame index.
+
 ## Version 0.3.1
 
 ### Bug Fixes

--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -157,9 +157,11 @@ class SpanEvaluator(BaseEvaluator):
         # token_start/token_end are positions within the sentence, so slice
         # positionally — the DataFrame's index labels are caller-defined
         # (e.g. global across sentences) and must not be used as positions.
-        between_tokens = (
-            df["token"].iloc[span1.token_end : span2.token_start or 0].tolist()
-        )
+        if span1.token_end is None or span2.token_start is None:
+            raise ValueError(
+                "Spans must have token_start/token_end set to check adjacency",
+            )
+        between_tokens = df["token"].iloc[span1.token_end : span2.token_start].tolist()
         non_skip_tokens = [
             tok for tok in between_tokens if tok.lower().strip() not in self.skip_words
         ]
@@ -613,19 +615,11 @@ class SpanEvaluator(BaseEvaluator):
         current_tokens = []
         current_start_indices = []
         current_token_start: int = 0
-        curr_char_position = 0
-        token_position = 0  # Add token position counter
 
         for idx, (_, row) in enumerate(df.iterrows()):
             entity_type = row[column]
             token = row["token"]
             token_start = row["start_indices"]
-            token_length = len(token)
-            # If this isn't the first token, add space before it
-            if idx > 0:
-                curr_char_position += 1  # Account for space between tokens
-
-            token_end = curr_char_position + token_length
 
             if entity_type == "O":
                 if current_entity_type and current_tokens:
@@ -649,8 +643,6 @@ class SpanEvaluator(BaseEvaluator):
                     current_start_indices = []
                     current_token_start = 0
 
-                curr_char_position = token_end
-                token_position += 1  # Increment token position
                 continue
 
             if entity_type != current_entity_type:
@@ -678,8 +670,6 @@ class SpanEvaluator(BaseEvaluator):
             else:
                 current_tokens.append(token)
                 current_start_indices.append(token_start)
-            curr_char_position = token_end
-            token_position += 1  # Increment token position
 
         # Handle final span
         if current_entity_type and current_tokens:

--- a/presidio_evaluator/evaluation/span_evaluator.py
+++ b/presidio_evaluator/evaluation/span_evaluator.py
@@ -154,11 +154,12 @@ class SpanEvaluator(BaseEvaluator):
         :param df: DataFrame containing the tokens
         :return: True if spans are adjacent, False otherwise
         """
-        # Slice tokens between span1 and span2 using the row indices
-        between_tokens = df.loc[
-            span1.token_end : (span2.token_start or 0) - 1,
-            "token",
-        ].tolist()
+        # token_start/token_end are positions within the sentence, so slice
+        # positionally — the DataFrame's index labels are caller-defined
+        # (e.g. global across sentences) and must not be used as positions.
+        between_tokens = (
+            df["token"].iloc[span1.token_end : span2.token_start or 0].tolist()
+        )
         non_skip_tokens = [
             tok for tok in between_tokens if tok.lower().strip() not in self.skip_words
         ]
@@ -621,7 +622,7 @@ class SpanEvaluator(BaseEvaluator):
             token_start = row["start_indices"]
             token_length = len(token)
             # If this isn't the first token, add space before it
-            if idx > df.index[0]:
+            if idx > 0:
                 curr_char_position += 1  # Account for space between tokens
 
             token_end = curr_char_position + token_length
@@ -693,7 +694,7 @@ class SpanEvaluator(BaseEvaluator):
                         start_indices=current_start_indices,
                         token_start=current_token_start,
                         current_tokens=current_tokens,
-                        idx=df.index[-1] + 1,
+                        idx=len(df),
                         normalized_start_indices=normalized_start_indices,
                         normalized_tokens=normalized_tokens,
                     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "presidio_evaluator"
-version = "0.3.1"
+version = "0.3.2"
 description = "A framework for evaluating Presidio's Named Entity Recognition performance"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/evaluation/test_span_evaluator.py
+++ b/tests/evaluation/test_span_evaluator.py
@@ -1740,3 +1740,42 @@ def test_positional_tokens_length_mismatch_raises():
     )
     with pytest.raises(ValueError, match="normalized"):
         SpanEvaluator._positional_tokens(span)
+
+
+def test_multi_sentence_df_does_not_merge_separated_same_type_spans(span_evaluator):
+    """Same-type spans separated by regular words must never be merged, regardless
+    of where their sentence sits in the dataset.
+    """
+    sentence_tokens = ["John", "visited", "Berlin", "with", "Mary", "yesterday"]
+    sentence_tags = ["PERSON", "O", "O", "O", "PERSON", "O"]
+
+    rows = []
+    for sentence_id in (0, 1):
+        char_position = 0
+        for token, tag in zip(sentence_tokens, sentence_tags):
+            rows.append(
+                {
+                    "sentence_id": sentence_id,
+                    "token": token,
+                    "annotation": tag,
+                    "prediction": tag,
+                    "start_indices": char_position,
+                }
+            )
+            char_position += len(token) + 1
+
+    # Default global RangeIndex (0..11), exactly as predict_dataset returns it.
+    df = pd.DataFrame(rows)
+
+    result = span_evaluator.calculate_score_on_df(results_df=df, level="entity")
+    person = result.per_type["PERSON"]
+
+    # Two PERSON spans per sentence, two sentences: "visited Berlin with" is not
+    # skip-word filler, so nothing may be merged.
+    assert person.num_annotated == 4, (
+        f"Expected 4 annotated PERSON spans (2 per sentence), got "
+        f"{person.num_annotated} — same-type spans were merged across "
+        f"intervening non-skip tokens"
+    )
+    assert person.num_predicted == 4
+    assert person.true_positives == 4

--- a/uv.lock
+++ b/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "presidio-evaluator"
-version = "0.3"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "faker" },


### PR DESCRIPTION
## Summary

`SpanEvaluator` scoring results depended on the DataFrame index of `results_df` — the native output of `predict_dataset()` (global RangeIndex) silently produced wrong span counts for every sentence except the first.

**Root cause:** `_create_spans` records `token_start`/`token_end` as positions *within the sentence* (via `enumerate`), but `_are_spans_adjacent` sliced the sentence DataFrame with label-based `df.loc[token_end : token_start - 1]`. For any sentence whose first row label isn't 0, that lookup reads the wrong rows — or returns nothing, and an empty between-tokens list counts as "adjacent". Result: same-type spans separated by regular words were silently merged (the two PERSON spans in *"John visited Berlin with Mary"* became one), deflating `num_annotated` / `num_predicted` / `true_positives`. Because gold and predictions were distorted symmetrically, headline precision/recall could still look plausible.

## Changes

- `_are_spans_adjacent`: positional `.iloc` slicing instead of label-based `.loc`.
- `_create_spans`: final span's end position is `len(df)` instead of `df.index[-1] + 1`; space-accounting guard compares positions (`idx > 0`) instead of index labels.
- Regression test `test_multi_sentence_df_does_not_merge_separated_same_type_spans`: two identical sentences must score identically regardless of where they sit in the dataset (fails before this fix with 3 spans instead of 4).
- CHANGELOG entry + version bump to 0.3.2 for the upcoming release.

Scoring is now index-agnostic: global, per-sentence, or any other index produces identical results.

## Impact

Any prior multi-sentence evaluation run through `predict_dataset()` was affected; re-running will shift reported numbers (that's the fix, not a regression). Existing tests never caught this because they all use single-sentence DataFrames whose labels coincide with positions.

## Test plan

- [x] New regression test fails on `main`, passes here
- [x] Full unit suite: 672 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)